### PR TITLE
Minor upgrades

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,17 +1,22 @@
----
+version: "2"
 linters:
   enable:
-    - revive
-    - gocyclo
-    - misspell
-
-linters-settings:
-  gocyclo:
-    min-complexity: 15
-
-  revive:
-    min-confidence: 0.21 # disables package comment warning
-
-issues:
-  exclude-use-default: false
-  exclude-case-sensitive: false
+  - gocyclo
+  - misspell
+  - revive
+  settings:
+    gocyclo:
+      min-complexity: 15
+  exclusions:
+    generated: lax
+    paths:
+    - third_party$
+    - builtin$
+    - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+    - third_party$
+    - builtin$
+    - examples$

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,8 @@
     "cSpell.words": [
         "alexhunt",
         "fsys",
+        "gocyclo",
+        "golangci",
         "iagotest",
         "mrand",
         "relab",

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.4
 
 require (
 	github.com/alexhunt7/ssher v0.0.0-20190216204854-d36569cf7047
-	github.com/docker/docker v28.3.0+incompatible
+	github.com/docker/docker v28.3.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/pkg/sftp v1.13.9
 	github.com/relab/wrfs v0.0.0-20220416082020-a641cd350078

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/docker v28.3.0+incompatible h1:ffS62aKWupCWdvcee7nBU9fhnmknOqDPaJAMtfK0ImQ=
-github.com/docker/docker v28.3.0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v28.3.1+incompatible h1:20+BmuA9FXlCX4ByQ0vYJcUEnOmRM6XljDnFWR+jCyY=
+github.com/docker/docker v28.3.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=

--- a/iago.go
+++ b/iago.go
@@ -1,3 +1,4 @@
+// Package iago provides a framework for running tasks on remote hosts.
 package iago
 
 import (

--- a/iagotest/iagotest.go
+++ b/iagotest/iagotest.go
@@ -1,3 +1,4 @@
+// Package iagotest provides utilities for external libraries to test using the iago package.
 package iagotest
 
 import (

--- a/iagotest/iagotest.go
+++ b/iagotest/iagotest.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 
@@ -116,7 +116,7 @@ func buildImage(t testing.TB, cli *client.Client) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := cli.ImageBuild(context.Background(), buildCtx, types.ImageBuildOptions{
+	res, err := cli.ImageBuild(context.Background(), buildCtx, build.ImageBuildOptions{
 		Dockerfile: "Dockerfile",
 		Tags:       []string{tag},
 	})

--- a/sftpfs/sftpfs.go
+++ b/sftpfs/sftpfs.go
@@ -1,3 +1,4 @@
+// Package sftpfs provides a filesystem interface to an SFTP server using the github.com/pkg/sftp package.
 package sftpfs
 
 import (


### PR DESCRIPTION
Minor upgrades.

- **chore: migrate golangci.yml to v2 format**
- **fix: update to build.ImageBuildOptions**
- **docs: add package documentation for iago, iagotest, and sftpfs**
- **fix: update docker dependency to v28.3.1**
