### PR TITLE
Replace ubuntu:rolling with alpine:latest for speed and robustness

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
         "golangci",
         "iagotest",
         "kevinburke",
+        "keygen",
         "knownhosts",
         "mrand",
         "Println",

--- a/iagotest/Dockerfile
+++ b/iagotest/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:rolling
+FROM alpine:latest
 
-RUN apt-get update && \
-    apt-get install -y openssh-server && \
-    mkdir -p /var/run/sshd && \
-    useradd -m -s /bin/bash root || true
+RUN apk add --no-cache openssh lsb-release && \
+    ssh-keygen -A && \
+    mkdir -p /root/.ssh && \
+    chmod 700 /root/.ssh
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/iagotest/entrypoint.sh
+++ b/iagotest/entrypoint.sh
@@ -1,8 +1,5 @@
-#!/bin/bash
+#!/bin/sh
 set -euo pipefail
-
-mkdir -p "$HOME/.ssh"
-chmod 700 "$HOME/.ssh"
 
 if [ -z "${AUTHORIZED_KEYS:-}" ]; then
   echo "AUTHORIZED_KEYS is not set" >&2
@@ -11,5 +8,5 @@ fi
 
 echo "$AUTHORIZED_KEYS" > "$HOME/.ssh/authorized_keys"
 chmod 600 "$HOME/.ssh/authorized_keys"
-service ssh start
+/usr/sbin/sshd
 exec "$@"


### PR DESCRIPTION
This replaces the ubuntu:rolling with alpine:latest for speed and robustness, and also simplifies the entrypoint script slightly to make it compatible with Alpine.
