### PR TITLE
Add ParseHosts into host aliases

### DIFF
--- a/ssh_config.go
+++ b/ssh_config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -245,4 +246,135 @@ func expand(path string) string {
 		return filepath.Join(homeDir, path[2:])
 	}
 	return path
+}
+
+// hostRangeRE matches a single PREFIX[lo-hi]SUFFIX numeric range within a host
+// token. Prefix and suffix are captured so non-numeric parts of the alias are
+// preserved (e.g. "rack2-node[1-4]").
+var hostRangeRE = regexp.MustCompile(`^(.*)\[(\d+)-(\d+)\](.*)$`)
+
+// ParseHosts resolves a comma-separated host specification to a slice of SSH
+// host aliases. Each token in the spec is handled as follows:
+//
+//   - A PREFIX[lo-hi]SUFFIX token with numeric bounds is expanded to individual
+//     aliases (e.g. "bb[1-30]" → bb1, bb2, …, bb30) without consulting the SSH
+//     config.
+//   - A token containing *, ?, or a non-numeric [...] bracket expression is
+//     treated as a glob and matched against the non-wildcard Host entries read
+//     from configFile. Wildcard SSH stanzas (e.g. "Host bb*") are skipped
+//     because they do not enumerate specific host names.
+//   - Any other token is returned verbatim as a literal alias.
+//
+// If configFile is empty, ~/.ssh/config is used. The config file is parsed at
+// most once, only when a glob token is encountered.
+func ParseHosts(spec, configFile string) ([]string, error) {
+	var (
+		hosts  []string
+		config *sshConfig
+	)
+	for _, token := range splitHostSpec(spec) {
+		if m := hostRangeRE.FindStringSubmatch(token); m != nil {
+			expanded, err := expandHostToken(m)
+			if err != nil {
+				return nil, err
+			}
+			hosts = append(hosts, expanded...)
+		} else if strings.ContainsAny(token, "*?[") {
+			// Lazy-load the SSH config only if we encounter a glob token, to avoid
+			// unnecessary parsing. We only need to parse once; hence the nil check.
+			if config == nil {
+				if configFile == "" {
+					if err := initHomeDir(); err != nil {
+						return nil, err
+					}
+					configFile = filepath.Join(homeDir, ".ssh", "config")
+				}
+				var err error
+				config, err = ParseSSHConfig(configFile)
+				if err != nil {
+					return nil, err
+				}
+			}
+			matched, err := config.hostAliases(token)
+			if err != nil {
+				return nil, err
+			}
+			hosts = append(hosts, matched...)
+		} else {
+			hosts = append(hosts, token)
+		}
+	}
+	return hosts, nil
+}
+
+// splitHostSpec splits a comma-separated host specification into trimmed,
+// non-empty tokens.
+func splitHostSpec(spec string) []string {
+	parts := strings.Split(strings.TrimSpace(spec), ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// expandHostToken expands a matched PREFIX[lo-hi]SUFFIX host range into
+// individual aliases. m is the result of hostRangeRE.FindStringSubmatch,
+// where m[0] is the full token, m[1] the prefix, m[2] lo, m[3] hi, m[4]
+// the suffix. Returns an error if the prefix or suffix contain brackets
+// (indicating a second range in the same token) or if the bounds are reversed.
+func expandHostToken(m []string) ([]string, error) {
+	token, prefix, loStr, hiStr, suffix := m[0], m[1], m[2], m[3], m[4]
+	if strings.ContainsAny(prefix, "[]") || strings.ContainsAny(suffix, "[]") {
+		return nil, fmt.Errorf("iago: malformed host range %q: at most one [lo-hi] range per host is supported", token)
+	}
+	lo, err := strconv.Atoi(loStr)
+	if err != nil {
+		return nil, fmt.Errorf("iago: malformed host range %q: invalid bounds: %w", token, err)
+	}
+	hi, err := strconv.Atoi(hiStr)
+	if err != nil {
+		return nil, fmt.Errorf("iago: malformed host range %q: invalid bounds: %w", token, err)
+	}
+	if lo > hi {
+		return nil, fmt.Errorf("iago: malformed host range %q: %d > %d", token, lo, hi)
+	}
+	// Preserve zero-padding only when at least one bound has a leading zero.
+	hasLeadingZero := (len(loStr) > 1 && loStr[0] == '0') || (len(hiStr) > 1 && hiStr[0] == '0')
+	width := max(len(loStr), len(hiStr))
+	out := make([]string, 0, hi-lo+1)
+	for i := lo; i <= hi; i++ {
+		if hasLeadingZero {
+			out = append(out, fmt.Sprintf("%s%0*d%s", prefix, width, i, suffix))
+		} else {
+			out = append(out, fmt.Sprintf("%s%d%s", prefix, i, suffix))
+		}
+	}
+	return out, nil
+}
+
+// hostAliases returns the non-wildcard Host aliases in c that match the given
+// glob pattern. Stanzas whose Host patterns contain SSH wildcard characters
+// (*, ?, !, []) are skipped because they cannot enumerate specific host names.
+// Aliases are returned in config-file order.
+func (cw *sshConfig) hostAliases(pattern string) ([]string, error) {
+	var hosts []string
+	for _, h := range cw.config.Hosts {
+		for _, p := range h.Patterns {
+			alias := p.String()
+			if strings.ContainsAny(alias, "*?![]") {
+				continue
+			}
+			matched, err := filepath.Match(pattern, alias)
+			if err != nil {
+				return nil, fmt.Errorf("iago: invalid glob pattern %q: %w", pattern, err)
+			}
+			if matched {
+				hosts = append(hosts, alias)
+			}
+		}
+	}
+	return hosts, nil
 }

--- a/ssh_config_test.go
+++ b/ssh_config_test.go
@@ -1,6 +1,9 @@
 package iago
 
 import (
+	"fmt"
+	"slices"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -123,6 +126,178 @@ func TestProxyJumpConfig(t *testing.T) {
 			}
 			if proxy != tt.wantProxy {
 				t.Errorf("get ProxyJump(%s) = %q, want %q", tt.hostAlias, proxy, tt.wantProxy)
+			}
+		})
+	}
+}
+
+// TestParseHostsRange covers numeric range expansion without consulting the
+// SSH config. Passing an empty configFile is safe here because no glob token
+// appears in any of the specs.
+func TestParseHostsRange(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "SingleRange",
+			spec: "bb[1-3]",
+			want: []string{"bb1", "bb2", "bb3"},
+		},
+		{
+			name: "SingleElementRange",
+			spec: "bb[5-5]",
+			want: []string{"bb5"},
+		},
+		{
+			name: "PrefixAndSuffix",
+			spec: "rack[1-2]-node",
+			want: []string{"rack1-node", "rack2-node"},
+		},
+		{
+			name: "RangePlusLiteral",
+			spec: "bb[1-3],nebula",
+			want: []string{"bb1", "bb2", "bb3", "nebula"},
+		},
+		{
+			name: "MultipleRangesAcrossTokens",
+			spec: "bb[1-2],cc[3-4]",
+			want: []string{"bb1", "bb2", "cc3", "cc4"},
+		},
+		{
+			name: "WhitespaceTrimmed",
+			spec: " bb[1-2] , , nebula ",
+			want: []string{"bb1", "bb2", "nebula"},
+		},
+		{
+			name: "LargeRange",
+			spec: "bb[1-30]",
+			want: func() []string {
+				out := make([]string, 30)
+				for i := range 30 {
+					out[i] = "bb" + strconv.Itoa(i+1)
+				}
+				return out
+			}(),
+		},
+		{
+			name:    "ReversedRange",
+			spec:    "bb[5-1]",
+			wantErr: true,
+		},
+		{
+			name:    "MultipleRangesInOneToken",
+			spec:    "bb[1-2]x[3-4]",
+			wantErr: true,
+		},
+		{
+			name:    "ReversedRangeInSecondToken",
+			spec:    "nebula,bb[7-1]",
+			wantErr: true,
+		},
+		{
+			name: "ZeroPaddedBothBounds",
+			spec: "node[01-03]",
+			want: []string{"node01", "node02", "node03"},
+		},
+		{
+			name: "ZeroPaddedLoBoundOnly",
+			spec: "node[01-10]",
+			want: []string{"node01", "node02", "node03", "node04", "node05", "node06", "node07", "node08", "node09", "node10"},
+		},
+		{
+			name: "ZeroPaddedWidthThree",
+			spec: "node[001-003]",
+			want: []string{"node001", "node002", "node003"},
+		},
+		{
+			name: "ZeroPaddedMixedWidth",
+			spec: "node[001-100]",
+			want: func() []string {
+				out := make([]string, 100)
+				for i := range 100 {
+					out[i] = fmt.Sprintf("node%03d", i+1)
+				}
+				return out
+			}(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseHosts(tt.spec, "")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseHosts(%q) error = %v, wantErr = %v", tt.spec, err, tt.wantErr)
+			}
+			if !tt.wantErr && !slices.Equal(got, tt.want) {
+				t.Errorf("ParseHosts(%q) = %v, want %v", tt.spec, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseHostsGlob covers glob-based host enumeration from the SSH config.
+// The testdata/config-hosts fixture has explicit entries bb1, bb2, bb3 plus a
+// wildcard "Host bb*" stanza (which must be skipped) and a "Host nebula" entry.
+func TestParseHostsGlob(t *testing.T) {
+	const cfg = "testdata/config-hosts"
+	tests := []struct {
+		name    string
+		spec    string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "WildcardMatchesExplicitEntries",
+			spec: "bb*",
+			want: []string{"bb1", "bb2", "bb3"},
+		},
+		{
+			name: "GlobBracketExpr",
+			// Numeric [lo-hi] is parsed via range expansion (not filepath.Match).
+			spec: "bb[1-3]",
+			want: []string{"bb1", "bb2", "bb3"},
+		},
+		{
+			name: "GlobBracketExprAllDigits",
+			// filepath.Match bracket expression: matches bb1, bb2, bb3
+			spec: "bb[123]",
+			want: []string{"bb1", "bb2", "bb3"},
+		},
+		{
+			name: "GlobBracketExprPartialMatch",
+			// Numeric [lo-hi] is parsed via range expansion (not filepath.Match).
+			spec: "bb[1-2]",
+			want: []string{"bb1", "bb2"},
+		},
+		{
+			name: "GlobNoMatch",
+			spec: "cc*",
+			want: nil,
+		},
+		{
+			name: "GlobPlusLiteral",
+			spec: "bb*,nebula",
+			want: []string{"bb1", "bb2", "bb3", "nebula"},
+		},
+		{
+			name:    "InvalidGlobPattern",
+			spec:    "bb[",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseHosts(tt.spec, cfg)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseHosts(%q, %q) error = %v, wantErr = %v", tt.spec, cfg, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("ParseHosts(%q, %q) = %v, want %v", tt.spec, cfg, got, tt.want)
 			}
 		})
 	}

--- a/testdata/config-hosts
+++ b/testdata/config-hosts
@@ -1,0 +1,22 @@
+Host bb1
+    HostName 10.0.0.1
+    StrictHostKeyChecking no
+
+Host bb2
+    HostName 10.0.0.2
+    StrictHostKeyChecking no
+
+Host bb3
+    HostName 10.0.0.3
+    StrictHostKeyChecking no
+
+Host bb*
+    User homer
+    StrictHostKeyChecking no
+
+Host nebula
+    HostName nebula.example.com
+    StrictHostKeyChecking no
+
+Host *
+    User testuser


### PR DESCRIPTION
Add ParseHosts(spec, configFile string) to resolve a comma-separated host specification into SSH host aliases. Each token is handled as:

- PREFIX[lo-hi]SUFFIX with numeric bounds: expanded to individual aliases (e.g. "bb[1-30]" -> bb1, bb2, ..., bb30).
- Token containing *, ?, or non-numeric [...]: treated as a glob matched against non-wildcard Host entries in the SSH config file.
- Plain literal: returned verbatim.

Unexported helpers: expandHostToken (range expansion), hostAliases (SSH config glob enumeration), splitHostSpec (comma split/trim).

Add testdata/config-hosts fixture and tests TestParseHostsRange and TestParseHostsGlob covering range expansion, glob filtering, mixed specs, and error cases.


