### PR TITLE
Shared ProxyJump connections across SSH Group

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ It supports executing tasks concurrently across multiple hosts, such as uploadin
 
 Iago executes *tasks* on a *group* of *hosts*.
 Tasks are functions that describe the *actions* to be performed on each individual host concurrently.
-The `iago.DialSSH` or `iago.NewSSHGroup` can be used to connect to existing SSH servers.
+Use `iago.NewSSHGroup` to connect to remote hosts defined in an SSH config file,
+or `iago.DialSSH` to connect to a single host directly.
 
 ```go
-hosts := []string{"host1", "host2", "host3"}
+hosts := []string{"wrk1", "wrk2", "wrk3"}
 configPath := "/path/to/ssh/config"
 
-// var g iago.Group is a set of iago.Host instances that the task will be applied to.
 g, err := iago.NewSSHGroup(hosts, configPath)
 if err != nil {
 	// handle error
@@ -22,26 +22,120 @@ if err != nil {
 defer g.Close()
 
 g.Run("Example Task", func(ctx context.Context, host iago.Host) error {
-  // This function will be executed concurrently on each host in the group.
-  // The context is used to control the execution of the task.
-  log.Println(host.Name())
-  return nil
+	// Executed concurrently on each host.
+	log.Println(host.Name())
+	return nil
 })
 ```
 
-We currently support connecting to remote hosts via SSH,
-but support for other connection methods can be added by implementing the `iago.Host` interface.
+Support for other connection methods can be added by implementing the `iago.Host` interface.
 
-Error handling is configured at the group level, using the `ErrorHandler` field of the `iago.Group` struct.
-By default, errors cause a panic, but you can set a custom error handler:
+Error handling is configured at the group level using the `ErrorHandler` field.
+By default, errors cause a panic, but you can set a custom handler:
 
 ```go
 g.ErrorHandler = func(e error) {
-  log.Printf("Task failed: %v", e)
+	log.Printf("Task failed: %v", e)
 }
 ```
 
-### Example
+## SSH config files
+
+`iago.NewSSHGroup` reads an OpenSSH-style config file (defaulting to `~/.ssh/config`).
+It honours the following per-host options: `Hostname`, `Port`, `User`, `IdentityFile`,
+`ProxyJump`, `ConnectTimeout`, `StrictHostKeyChecking`, and `UserKnownHostsFile`.
+OpenSSH's **first-match-wins** rule applies: the first `Host` stanza that matches a given
+alias wins for each option.
+
+Connections must be passphrase-free at connect time.
+Load keys into `ssh-agent` ahead of time (entering the passphrase once):
+
+```sh
+ssh-add
+```
+
+Alternatively, point `IdentityFile` at a passphrase-less private key.
+
+### Example config
+
+The following config connects 15 workers through a bastion host using a single wildcard stanza:
+
+```ssh-config
+Host *
+  IdentityFile ~/.ssh/id_ed25519
+  UserKnownHostsFile ~/.ssh/known_hosts
+
+Host bastion
+  User deploy
+  HostName bastion.example.com
+
+Host wrk*
+  HostName %h.cluster.example.com
+  User deploy
+  ProxyJump bastion
+  StrictHostKeyChecking no
+```
+
+The `%h` token expands to the alias, so `wrk7` resolves to `wrk7.cluster.example.com`.
+No per-host stanzas are needed for the workers — the wildcard covers all of them.
+
+### Resolving host aliases with ParseHosts
+
+`iago.ParseHosts` resolves a comma-separated host spec to a slice of SSH aliases
+suitable for passing to `NewSSHGroup`. Each token is handled as follows:
+
+| Form | Example | Best for |
+| --- | --- | --- |
+| Literal list | `atlas,titan,helios` | A small, fixed set of irregularly named hosts |
+| Numeric range | `wrk[1-15]` | Numerically named hosts; no config lookup needed |
+| Glob | `gpu-*` | Irregularly named hosts that share a role prefix; config is the membership list |
+
+```go
+aliases, err := iago.ParseHosts("wrk[1-15]", configPath)
+// aliases == []string{"wrk1", "wrk2", ..., "wrk15"}
+
+g, err := iago.NewSSHGroup(aliases, configPath)
+```
+
+The numeric range form is usually the cleanest for regular names: it expands without
+consulting the config file and works even when only a wildcard stanza is present.
+
+The glob form is most useful when host names are irregular — for example, GPU nodes
+named after Greek titans rather than by number. The config file becomes the source of
+truth for cluster membership: adding or removing a `Host` stanza automatically changes
+what the glob returns, with no code change required.
+
+```ssh-config
+Host gpu-atlas gpu-titan gpu-helios
+  HostName %h.cluster.example.com
+  User deploy
+  ProxyJump bastion
+  StrictHostKeyChecking no
+```
+
+```go
+aliases, err := iago.ParseHosts("gpu-*", configPath)
+// aliases == []string{"gpu-atlas", "gpu-titan", "gpu-helios"}
+```
+
+Multiple space-separated aliases can share one stanza; `%h` still expands per-alias.
+When a fourth GPU node is added to the config, `gpu-*` picks it up without touching
+any Go code.
+
+### ProxyJump and connection sharing
+
+When `Host wrk1` has `ProxyJump bastion`, iago dials `bastion` first and tunnels
+the connection to `wrk1` through it. `NewSSHGroup` dials each unique `ProxyJump`
+target **once** and reuses that connection for every alias that routes through it.
+A group of 15 workers that all share `ProxyJump bastion` opens exactly **one**
+TCP/SSH connection to `bastion` — equivalent to what OpenSSH's `ControlMaster` /
+`ControlPersist` achieves for the system `ssh` client, without requiring a background
+process or a Unix-domain socket.
+
+The shared connection is owned by the `Group` and closed by `group.Close()`.
+Closing an individual `iago.Host` closes only that host's tunnel.
+
+## Example
 
 The following example downloads a file from each remote host.
 The file is downloaded to a temporary directory created by the test framework and named `os.<hostname>`.
@@ -51,26 +145,26 @@ This example uses the `iagotest` package, which spawns docker containers and con
 
 ```go
 func TestIago(t *testing.T) {
-  dir := t.TempDir()
+	dir := t.TempDir()
 
-  // The iagotest package provides a helper function that automatically
-  // builds and starts docker containers with an exposed SSH port for testing.
-  g := iagotest.CreateSSHGroup(t, 4, false)
+	// The iagotest package provides a helper function that automatically
+	// builds and starts docker containers with an exposed SSH port for testing.
+	g := iagotest.CreateSSHGroup(t, 4, false)
 
-  g.Run("Download files", func(ctx context.Context, host iago.Host) error {
-    src, err := iago.NewPath("/etc", "os-release")
-    if err != nil {
-      return err
-    }
-    dest, err := iago.NewPath(dir, "os")
-    if err != nil {
-      return err
-    }
-    return iago.Download{
-      Src:  src,
-      Dest: dest,
-      Perm: iago.NewPerm(0o644),
-    }.Apply(ctx, host)
-  })
+	g.Run("Download files", func(ctx context.Context, host iago.Host) error {
+		src, err := iago.NewPath("/etc", "os-release")
+		if err != nil {
+			return err
+		}
+		dest, err := iago.NewPath(dir, "os")
+		if err != nil {
+			return err
+		}
+		return iago.Download{
+			Src:  src,
+			Dest: dest,
+			Perm: iago.NewPerm(0o644),
+		}.Apply(ctx, host)
+	})
 }
 ```

--- a/iago.go
+++ b/iago.go
@@ -75,6 +75,12 @@ type Group struct {
 	Hosts        []Host
 	ErrorHandler ErrorHandler
 	Timeout      time.Duration
+
+	// sharedClosers are resources owned by the group rather than by any
+	// individual host (for example, a single SSH connection to a ProxyJump
+	// host shared by all targets that route through it). They are closed
+	// after all hosts on [Group.Close].
+	sharedClosers []io.Closer
 }
 
 // NewGroup returns a new Group consisting of the given hosts.
@@ -106,11 +112,15 @@ func (g Group) Run(name string, f func(context.Context, Host) error) {
 	}
 }
 
-// Close closes any connections to hosts.
+// Close closes any connections to hosts and any group-owned shared resources
+// (such as ProxyJump connections shared across hosts in this group).
 func (g Group) Close() (err error) {
 	for _, h := range g.Hosts {
 		// Join close errors; nil errors are discarded by Join.
 		err = errors.Join(err, h.Close())
+	}
+	for _, c := range g.sharedClosers {
+		err = errors.Join(err, c.Close())
 	}
 	return err
 }

--- a/iagotest/Dockerfile
+++ b/iagotest/Dockerfile
@@ -3,7 +3,15 @@ FROM alpine:latest
 RUN apk add --no-cache openssh lsb-release && \
     ssh-keygen -A && \
     mkdir -p /root/.ssh && \
-    chmod 700 /root/.ssh
+    chmod 700 /root/.ssh && \
+    printf '%s\n' \
+        'HostKey /etc/ssh/ssh_host_rsa_key' \
+        'HostKey /etc/ssh/ssh_host_ed25519_key' \
+        'PermitRootLogin yes' \
+        'AuthorizedKeysFile .ssh/authorized_keys' \
+        'AllowTcpForwarding yes' \
+        'Subsystem sftp internal-sftp' \
+        > /etc/ssh/sshd_config
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/iagotest/ssh_group_test.go
+++ b/iagotest/ssh_group_test.go
@@ -4,13 +4,67 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/relab/iago"
 )
+
+// countingProxy is a transparent TCP proxy that counts how many times a new
+// connection is accepted. It is used in tests to verify that a single TCP
+// connection to the jump host is reused across all targets rather than one
+// connection being dialed per target.
+type countingProxy struct {
+	accepted atomic.Int64
+	addr     string
+	ln       net.Listener
+}
+
+func newCountingProxy(t *testing.T, target string) *countingProxy {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := &countingProxy{addr: ln.Addr().String(), ln: ln}
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		p.serve(target)
+	})
+	t.Cleanup(func() {
+		ln.Close()
+		wg.Wait()
+	})
+	return p
+}
+
+func (p *countingProxy) serve(target string) {
+	for {
+		src, err := p.ln.Accept()
+		if err != nil {
+			return
+		}
+		p.accepted.Add(1)
+		dst, err := net.Dial("tcp", target)
+		if err != nil {
+			src.Close()
+			continue
+		}
+		go func() {
+			defer src.Close()
+			defer dst.Close()
+			var wg sync.WaitGroup
+			wg.Go(func() { io.Copy(dst, src) })
+			wg.Go(func() { io.Copy(src, dst) })
+			wg.Wait()
+		}()
+	}
+}
 
 func TestNewSSHGroup(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -152,7 +206,16 @@ func TestNewSSHGroupProxyJump(t *testing.T) {
 		t.Cleanup(cleanupContainer(t, cli, network, targets[i].id))
 	}
 
-	configEntries := []string{sshConfigEntry(jump.hostAlias, "127.0.0.1", "root", keyFiles.privateKeyPath, jump.port)}
+	// Route the jump host through a counting proxy so we can assert that
+	// NewSSHGroup dials the jump exactly once, regardless of how many targets
+	// share the same ProxyJump spec.
+	proxy := newCountingProxy(t, jump.address)
+	_, proxyPort, err := net.SplitHostPort(proxy.addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configEntries := []string{sshConfigEntry(jump.hostAlias, "127.0.0.1", "root", keyFiles.privateKeyPath, proxyPort)}
 	for _, tgt := range targets {
 		// Hostname must be the Docker-assigned container name, which is the
 		// DNS alias registered on the Docker network. The host-mapped ephemeral
@@ -189,6 +252,12 @@ func TestNewSSHGroupProxyJump(t *testing.T) {
 
 	if len(group.Hosts) != numTargets {
 		t.Fatalf("group has %d hosts, want %d", len(group.Hosts), numTargets)
+	}
+
+	// Assert that the jump host was dialed exactly once. If sharing is broken
+	// and each target opens its own jump connection, this will equal numTargets.
+	if n := proxy.accepted.Load(); n != 1 {
+		t.Errorf("jump host dialed %d times, want 1 (shared connection not reused)", n)
 	}
 
 	group.ErrorHandler = func(e error) { t.Error(e) }

--- a/iagotest/ssh_group_test.go
+++ b/iagotest/ssh_group_test.go
@@ -124,6 +124,84 @@ func TestNewSSHGroup(t *testing.T) {
 	})
 }
 
+// TestNewSSHGroupProxyJump verifies that NewSSHGroup can dial multiple target
+// hosts via a shared ProxyJump connection. The jump container is reached on
+// its host-mapped port; targets are reached through the jump on the internal
+// docker network using their container alias on port 22.
+//
+// NewSSHGroup reuses one *ssh.Client per unique ProxyJump spec, so a single
+// TCP connection to the jump host serves all N targets that share it.
+func TestNewSSHGroupProxyJump(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyFiles := setupSSHKeys(t, tmpDir)
+
+	cli, network := setupContainerEnvironment(t, true)
+	t.Cleanup(cleanupNetwork(t, cli, network))
+
+	// Jump host: reached from this test on a host-mapped ephemeral port.
+	jump := createContainerWithInfo(t, cli, network, "jump", keyFiles.signer)
+	t.Cleanup(cleanupContainer(t, cli, network, jump.id))
+
+	// Targets: reached from inside the jump container on the docker network,
+	// addressed by the container's network alias on the internal port 22.
+	numTargets := 3
+	targets := make([]containerInfo, numTargets)
+	for i := range numTargets {
+		alias := fmt.Sprintf("target-%d", i+1)
+		targets[i] = createContainerWithInfo(t, cli, network, alias, keyFiles.signer)
+		t.Cleanup(cleanupContainer(t, cli, network, targets[i].id))
+	}
+
+	configEntries := []string{sshConfigEntry(jump.hostAlias, "127.0.0.1", "root", keyFiles.privateKeyPath, jump.port)}
+	for _, tgt := range targets {
+		// Hostname must be the Docker-assigned container name, which is the
+		// DNS alias registered on the Docker network. The host-mapped ephemeral
+		// port is only reachable from outside Docker; the jump container reaches
+		// the target on the internal port 22.
+		configEntries = append(configEntries, fmt.Sprintf(`Host %s
+	Hostname %s
+	User root
+	IdentityFile %s
+	Port 22
+	ProxyJump %s
+	StrictHostKeyChecking no
+	UserKnownHostsFile /dev/null
+`, tgt.hostAlias, tgt.id, keyFiles.privateKeyPath, jump.hostAlias))
+	}
+
+	configPath := filepath.Join(tmpDir, "config")
+	createSSHConfigFile(t, configPath, configEntries)
+
+	hostAliases := make([]string, numTargets)
+	for i, tgt := range targets {
+		hostAliases[i] = tgt.hostAlias
+	}
+
+	group, err := iago.NewSSHGroup(hostAliases, configPath)
+	if err != nil {
+		t.Fatalf("NewSSHGroup: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := group.Close(); err != nil {
+			t.Errorf("group.Close: %v", err)
+		}
+	})
+
+	if len(group.Hosts) != numTargets {
+		t.Fatalf("group has %d hosts, want %d", len(group.Hosts), numTargets)
+	}
+
+	group.ErrorHandler = func(e error) { t.Error(e) }
+	group.Run("hostname via proxy", func(ctx context.Context, host iago.Host) error {
+		var sb strings.Builder
+		if err := (iago.Shell{Command: "hostname", Stdout: &sb}).Apply(ctx, host); err != nil {
+			return err
+		}
+		t.Logf("hostname on %s: %s", host.Name(), strings.TrimSpace(sb.String()))
+		return nil
+	})
+}
+
 func TestNewSSHGroupInvalidConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/ssh.go
+++ b/ssh.go
@@ -19,7 +19,6 @@ type sshHost struct {
 	name       string
 	env        map[string]string
 	client     *ssh.Client
-	jumpClient *ssh.Client // non-nil when connected via ProxyJump; closed with this host
 	sftpClient *sftp.Client
 	fsys       fs.FS
 	vars       map[string]any
@@ -31,12 +30,13 @@ func DialSSH(name, addr string, cfg *ssh.ClientConfig) (Host, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newHostFromClient(name, client, nil)
+	return newHostFromClient(name, client)
 }
 
 // dialViaProxy connects to a remote host by tunnelling through an already-established
-// SSH connection to a jump host. The jump client is owned by the returned Host and
-// closed when the Host is closed.
+// SSH connection to a jump host. The jump client is not owned by the returned Host;
+// its lifetime is managed by the caller (typically [NewSSHGroup], which shares one
+// jump client across all targets that route through the same ProxyJump spec).
 func dialViaProxy(name, addr string, cfg *ssh.ClientConfig, jump *ssh.Client) (Host, error) {
 	ctx := context.Background()
 	if cfg.Timeout > 0 {
@@ -52,13 +52,12 @@ func dialViaProxy(name, addr string, cfg *ssh.ClientConfig, jump *ssh.Client) (H
 	if err != nil {
 		return nil, err
 	}
-	return newHostFromClient(name, ssh.NewClient(ncc, chans, reqs), jump)
+	return newHostFromClient(name, ssh.NewClient(ncc, chans, reqs))
 }
 
 // newHostFromClient wraps an established *ssh.Client as a Host, creating the SFTP
-// sub-client and fetching the remote environment. jumpClient may be nil; if non-nil
-// it is closed when the Host is closed.
-func newHostFromClient(name string, client *ssh.Client, jumpClient *ssh.Client) (Host, error) {
+// sub-client and fetching the remote environment.
+func newHostFromClient(name string, client *ssh.Client) (Host, error) {
 	sftpClient, err := sftp.NewClient(client)
 	if err != nil {
 		return nil, err
@@ -71,7 +70,6 @@ func newHostFromClient(name string, client *ssh.Client, jumpClient *ssh.Client) 
 		name:       name,
 		env:        env,
 		client:     client,
-		jumpClient: jumpClient,
 		sftpClient: sftpClient,
 		fsys:       sftpfs.New(sftpClient, "/"),
 		vars:       make(map[string]any),
@@ -92,8 +90,14 @@ func newHostFromClient(name string, client *ssh.Client, jumpClient *ssh.Client) 
 // files specified by UserKnownHostsFile (the default known_hosts files will be used if
 // this option is not specified).
 //
-// Finally, the specified hosts must all contain a authorized_keys file containing the
+// The specified hosts must all contain a authorized_keys file containing the
 // public key of the user running this program.
+//
+// When several aliases share the same ProxyJump spec, a single TCP/SSH connection
+// to the jump host is dialed once and reused for every target tunnelled through it.
+// This mirrors what OpenSSH's ControlMaster provides for the system ssh client and
+// avoids opening one proxy connection per target alias. The shared jump clients are
+// owned by the returned [Group] and closed by [Group.Close].
 func NewSSHGroup(hostAliases []string, sshConfigFile string) (group Group, err error) {
 	if sshConfigFile == "" {
 		if err = initHomeDir(); err != nil {
@@ -105,38 +109,68 @@ func NewSSHGroup(hostAliases []string, sshConfigFile string) (group Group, err e
 	if err != nil {
 		return group, err
 	}
+
+	jumpClients := make(map[string]*ssh.Client)
 	hosts := make([]Host, 0, len(hostAliases))
-	for _, h := range hostAliases {
-		clientCfg, err := config.ClientConfig(h)
-		if err != nil {
-			return group, err
+	defer func() {
+		if err == nil {
+			return
 		}
-		proxySpec, err := config.get(h, "ProxyJump")
-		if err != nil {
-			return group, err
+		for _, h := range hosts {
+			_ = h.Close()
 		}
-		targetAddr := config.ConnectAddr(h)
+		for _, jc := range jumpClients {
+			_ = jc.Close()
+		}
+	}()
+
+	for _, alias := range hostAliases {
 		var host Host
-		var hostErr error
-		if proxySpec != "" && proxySpec != "none" {
-			jumpCfg, err := config.ClientConfig(proxySpec)
-			if err != nil {
-				return group, fmt.Errorf("proxy jump %q for %q: %w", proxySpec, h, err)
-			}
-			jumpClient, err := ssh.Dial("tcp", config.ConnectAddr(proxySpec), jumpCfg)
-			if err != nil {
-				return group, fmt.Errorf("dial proxy jump %q: %w", proxySpec, err)
-			}
-			host, hostErr = dialViaProxy(h, targetAddr, clientCfg, jumpClient)
-		} else {
-			host, hostErr = DialSSH(h, targetAddr, clientCfg)
-		}
-		if hostErr != nil {
-			return group, hostErr
+		host, err = dialHost(alias, config, jumpClients)
+		if err != nil {
+			return group, err
 		}
 		hosts = append(hosts, host)
 	}
-	return NewGroup(hosts), nil
+
+	group = NewGroup(hosts)
+	for _, jc := range jumpClients {
+		group.sharedClosers = append(group.sharedClosers, jc)
+	}
+	return group, nil
+}
+
+// dialHost dials a single host using the given SSH config. If the host has a
+// ProxyJump, jumpClients is consulted first: if a client for that proxy spec
+// already exists it is reused, otherwise a new connection to the proxy is
+// dialed and stored in the map. The map is the caller's responsibility to
+// close (typically via [Group.sharedClosers]).
+func dialHost(alias string, config *sshConfig, jumpClients map[string]*ssh.Client) (Host, error) {
+	clientCfg, err := config.ClientConfig(alias)
+	if err != nil {
+		return nil, err
+	}
+	proxySpec, err := config.get(alias, "ProxyJump")
+	if err != nil {
+		return nil, err
+	}
+	targetAddr := config.ConnectAddr(alias)
+	if proxySpec == "" || proxySpec == "none" {
+		return DialSSH(alias, targetAddr, clientCfg)
+	}
+	jumpClient, ok := jumpClients[proxySpec]
+	if !ok {
+		jumpCfg, err := config.ClientConfig(proxySpec)
+		if err != nil {
+			return nil, fmt.Errorf("proxy jump %q for %q: %w", proxySpec, alias, err)
+		}
+		jumpClient, err = ssh.Dial("tcp", config.ConnectAddr(proxySpec), jumpCfg)
+		if err != nil {
+			return nil, fmt.Errorf("dial proxy jump %q: %w", proxySpec, err)
+		}
+		jumpClients[proxySpec] = jumpClient
+	}
+	return dialViaProxy(alias, targetAddr, clientCfg, jumpClient)
 }
 
 // fetchEnv returns a map containing the environment variables of the ssh server.
@@ -222,13 +256,13 @@ func (h *sshHost) NewCommand() (CmdRunner, error) {
 	}, nil
 }
 
-// Close closes the connection to the host, including any proxy jump connection.
+// Close closes the connection to the host.
+//
+// Note: when the host was dialed via ProxyJump by [NewSSHGroup], the underlying
+// jump connection is shared with other hosts and not closed here; it is closed
+// by [Group.Close].
 func (h *sshHost) Close() error {
-	err := errors.Join(h.sftpClient.Close(), h.client.Close())
-	if h.jumpClient != nil {
-		err = errors.Join(err, h.jumpClient.Close())
-	}
-	return err
+	return errors.Join(h.sftpClient.Close(), h.client.Close())
 }
 
 func (h *sshHost) SetVar(key string, val any) {

--- a/ssh.go
+++ b/ssh.go
@@ -90,7 +90,7 @@ func newHostFromClient(name string, client *ssh.Client) (Host, error) {
 // files specified by UserKnownHostsFile (the default known_hosts files will be used if
 // this option is not specified).
 //
-// The specified hosts must all contain a authorized_keys file containing the
+// The specified hosts must all contain an authorized_keys file containing the
 // public key of the user running this program.
 //
 // When several aliases share the same ProxyJump spec, a single TCP/SSH connection


### PR DESCRIPTION
Previously, NewSSHGroup opened a separate TCP/SSH connection to the
jump host for each target alias that used it. With N targets behind
the same ProxyJump, this produced N concurrent handshakes against the
proxy and quickly exhausted OpenSSH's default MaxStartups limit,
causing connection timeouts for higher-indexed hosts.

NewSSHGroup now dials each unique ProxyJump spec once and reuses that
connection for every target tunnelled through it — equivalent to what
OpenSSH's ControlMaster/ControlPersist achieves for the system ssh
client, without requiring a Unix-domain socket or background process.

Implementation details:
- dialHost helper encapsulates per-alias dialing with a shared
  jumpClients map (keyed by ProxyJump spec).
- sshHost no longer owns its jump connection; ownership transfers to
  Group via a new sharedClosers field, closed after all hosts on
  Group.Close().
- Error path in NewSSHGroup now cleans up partially-dialed hosts and
  jump clients on failure (previously leaked).
- Dockerfile for test containers replaced with a controlled sshd_config
  that explicitly sets AllowTcpForwarding and the sftp subsystem, which
  are required for the new TestNewSSHGroupProxyJump integration test.
- README rewritten with a complete SSH config guide covering supported
  options, authentication, ParseHosts spec forms, and ProxyJump
  connection sharing.
