### PR TITLE
Set HostKeyAlgorithms based on known_hosts to prevent key mismatch

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
 		".git/{index,*refs,*HEAD}",
 		".vscode",
 		".vscode-insiders",
+        "testdata",
 		"go.mod",
 		"go.sum"
 	],
@@ -22,6 +23,8 @@
         "keygen",
         "knownhosts",
         "mrand",
+        "myhost",
+        "nistp",
         "Println",
         "proxyuser",
         "relab",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,7 @@
         "mrand",
         "myhost",
         "nistp",
+        "nomatch",
         "Println",
         "proxyuser",
         "relab",

--- a/ssh_config.go
+++ b/ssh_config.go
@@ -109,11 +109,12 @@ func (cw *sshConfig) ClientConfig(hostAlias string) (*ssh.ClientConfig, error) {
 	}
 
 	clientConfig := &ssh.ClientConfig{
-		Config:          ssh.Config{},
-		User:            username,
-		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signers...)},
-		HostKeyCallback: hostKeyCallback,
-		Timeout:         timeout,
+		Config:            ssh.Config{},
+		User:              username,
+		Auth:              []ssh.AuthMethod{ssh.PublicKeys(signers...)},
+		HostKeyCallback:   hostKeyCallback,
+		HostKeyAlgorithms: cw.knownHostAlgorithms(hostAlias),
+		Timeout:           timeout,
 	}
 	return clientConfig, nil
 }
@@ -225,6 +226,64 @@ func (cw *sshConfig) getHostKeyCallback(hostAlias string) (hostKeyCallback ssh.H
 		return nil, fmt.Errorf("iago: failed to create host key callback for %s: %w", hostAlias, err)
 	}
 	return hostKeyCallback, nil
+}
+
+// knownHostAlgorithms returns the host key algorithms present in the known_hosts
+// files for the resolved address of hostAlias. The returned slice is used as
+// [ssh.ClientConfig.HostKeyAlgorithms] so that Go's crypto/ssh requests only key
+// types already recorded in known_hosts during the server handshake.
+//
+// Without this, Go's crypto/ssh uses its own preference order (ECDSA before
+// ED25519), which causes "knownhosts: key mismatch" when the server offers
+// multiple key types but only one of them is stored locally.
+//
+// Returns nil when strict host key checking is disabled or no matching entries
+// are found; in those cases the caller must not constrain HostKeyAlgorithms.
+func (cw *sshConfig) knownHostAlgorithms(hostAlias string) []string {
+	strictHostKeyChecking, err := cw.get(hostAlias, "StrictHostKeyChecking")
+	if err != nil || strictHostKeyChecking == "no" {
+		return nil
+	}
+	userKnownHostsFile, err := cw.get(hostAlias, "UserKnownHostsFile")
+	if err != nil || userKnownHostsFile == "" {
+		return nil
+	}
+	addr := cw.ConnectAddr(hostAlias)
+	if addr == "" {
+		return nil
+	}
+	norm := knownhosts.Normalize(addr)
+
+	var algos []string
+	seen := make(map[string]bool)
+	for file := range strings.SplitSeq(userKnownHostsFile, " ") {
+		file = expand(file)
+		data, err := os.ReadFile(file)
+		if err != nil {
+			continue
+		}
+		for line := range strings.Lines(string(data)) {
+			line = strings.TrimSpace(line)
+			// Skip comments, blank lines, hashed hostnames, and markers.
+			if line == "" || line[0] == '#' || line[0] == '|' || line[0] == '@' {
+				continue
+			}
+			fields := strings.Fields(line)
+			if len(fields) < 3 {
+				continue
+			}
+			// fields[0] is a comma-separated list of hostname patterns.
+			// fields[1] is the key type (e.g. "ssh-ed25519").
+			for h := range strings.SplitSeq(fields[0], ",") {
+				if h == norm && !seen[fields[1]] {
+					algos = append(algos, fields[1])
+					seen[fields[1]] = true
+					break
+				}
+			}
+		}
+	}
+	return algos
 }
 
 // createHostKeyCallback returns a HostKeyCallback that checks the host keys against the known hosts files.

--- a/ssh_config.go
+++ b/ssh_config.go
@@ -312,6 +312,8 @@ func createHostKeyCallback(userKnownHostsFilesPaths []string) (ssh.HostKeyCallba
 
 // matchesHashedHost reports whether host matches the hashed known_hosts pattern.
 // The pattern must be in the |1|<base64-salt>|<base64-hash> format used by OpenSSH.
+// OpenSSH uses HMAC-SHA1 for this format (type "1"); SHA1 is intentional here for
+// compatibility with existing known_hosts files and must not be upgraded.
 func matchesHashedHost(pattern, host string) bool {
 	// Split on "|": a valid hashed entry produces ["", "1", salt, hash].
 	parts := strings.SplitN(pattern, "|", 4)
@@ -326,7 +328,7 @@ func matchesHashedHost(pattern, host string) bool {
 	if err != nil {
 		return false
 	}
-	mac := hmac.New(sha1.New, salt)
+	mac := hmac.New(sha1.New, salt) //nolint:gosec // SHA1 required by OpenSSH known_hosts format
 	mac.Write([]byte(host))
 	return hmac.Equal(mac.Sum(nil), hashBytes)
 }

--- a/ssh_config.go
+++ b/ssh_config.go
@@ -242,6 +242,10 @@ func (cw *sshConfig) getHostKeyCallback(hostAlias string) (hostKeyCallback ssh.H
 //
 // Returns nil when strict host key checking is disabled or no matching entries
 // are found; in those cases the caller must not constrain HostKeyAlgorithms.
+//
+// Note: entries with OpenSSH glob wildcard patterns (e.g. *.example.com) or
+// negation prefixes (e.g. !host) in the hostname field are not matched; only
+// exact hostname matches are supported.
 func (cw *sshConfig) knownHostAlgorithms(hostAlias string) []string {
 	strictHostKeyChecking, err := cw.get(hostAlias, "StrictHostKeyChecking")
 	if err != nil || strictHostKeyChecking == "no" {

--- a/ssh_config.go
+++ b/ssh_config.go
@@ -1,6 +1,9 @@
 package iago
 
 import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -264,18 +267,25 @@ func (cw *sshConfig) knownHostAlgorithms(hostAlias string) []string {
 		}
 		for line := range strings.Lines(string(data)) {
 			line = strings.TrimSpace(line)
-			// Skip comments, blank lines, hashed hostnames, and markers.
-			if line == "" || line[0] == '#' || line[0] == '|' || line[0] == '@' {
+			// Skip comments, blank lines, and markers.
+			if line == "" || line[0] == '#' || line[0] == '@' {
 				continue
 			}
 			fields := strings.Fields(line)
 			if len(fields) < 3 {
 				continue
 			}
-			// fields[0] is a comma-separated list of hostname patterns.
+			// fields[0] is a comma-separated list of hostname patterns or a
+			// single hashed entry in the |1|salt|hash format.
 			// fields[1] is the key type (e.g. "ssh-ed25519").
 			for h := range strings.SplitSeq(fields[0], ",") {
-				if h == norm && !seen[fields[1]] {
+				var matches bool
+				if strings.HasPrefix(h, "|1|") {
+					matches = matchesHashedHost(h, norm)
+				} else {
+					matches = h == norm
+				}
+				if matches && !seen[fields[1]] {
 					algos = append(algos, fields[1])
 					seen[fields[1]] = true
 					break
@@ -298,6 +308,27 @@ func createHostKeyCallback(userKnownHostsFilesPaths []string) (ssh.HostKeyCallba
 		userKnownHostsFiles = append(userKnownHostsFiles, file)
 	}
 	return knownhosts.New(userKnownHostsFiles...)
+}
+
+// matchesHashedHost reports whether host matches the hashed known_hosts pattern.
+// The pattern must be in the |1|<base64-salt>|<base64-hash> format used by OpenSSH.
+func matchesHashedHost(pattern, host string) bool {
+	// Split on "|": a valid hashed entry produces ["", "1", salt, hash].
+	parts := strings.SplitN(pattern, "|", 4)
+	if len(parts) != 4 || parts[0] != "" || parts[1] != "1" {
+		return false
+	}
+	salt, err := base64.StdEncoding.DecodeString(parts[2])
+	if err != nil {
+		return false
+	}
+	hashBytes, err := base64.StdEncoding.DecodeString(parts[3])
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha1.New, salt)
+	mac.Write([]byte(host))
+	return hmac.Equal(mac.Sum(nil), hashBytes)
 }
 
 func expand(path string) string {

--- a/ssh_config.go
+++ b/ssh_config.go
@@ -332,7 +332,7 @@ func matchesHashedHost(pattern, host string) bool {
 	if err != nil {
 		return false
 	}
-	mac := hmac.New(sha1.New, salt) //nolint:gosec // SHA1 required by OpenSSH known_hosts format
+	mac := hmac.New(sha1.New, salt) // SHA1 required by OpenSSH known_hosts format
 	mac.Write([]byte(host))
 	return hmac.Equal(mac.Sum(nil), hashBytes)
 }

--- a/ssh_config_test.go
+++ b/ssh_config_test.go
@@ -137,7 +137,7 @@ func TestProxyJumpConfig(t *testing.T) {
 //   - a single key type for "myhost" at a non-default port (2222), whose
 //     known_hosts entry uses the "[host]:port" format,
 //   - an entry for "other-host" that must never match "myhost" lookups,
-//   - a hashed entry (starting with "|1|") that must be silently skipped.
+//   - a hashed entry (starting with "|1|") matched via HMAC-SHA1 by matchesHashedHost.
 func TestKnownHostAlgorithms(t *testing.T) {
 	config, err := ParseSSHConfig("testdata/config-known-hosts")
 	if err != nil {
@@ -166,7 +166,7 @@ func TestKnownHostAlgorithms(t *testing.T) {
 		},
 		{
 			name:      "NoMatchReturnsNil",
-			hostAlias: "nomatch",
+			hostAlias: "no-match",
 			wantAlgos: nil,
 		},
 	}

--- a/ssh_config_test.go
+++ b/ssh_config_test.go
@@ -166,7 +166,7 @@ func TestKnownHostAlgorithms(t *testing.T) {
 		},
 		{
 			name:      "NoMatchReturnsNil",
-			hostAlias: "no-match",
+			hostAlias: "nomatch",
 			wantAlgos: nil,
 		},
 	}

--- a/ssh_config_test.go
+++ b/ssh_config_test.go
@@ -131,6 +131,56 @@ func TestProxyJumpConfig(t *testing.T) {
 	}
 }
 
+// TestKnownHostAlgorithms exercises the knownHostAlgorithms helper against the
+// testdata/known_hosts fixture. The fixture contains:
+//   - two key types for "myhost" at the default port (22),
+//   - a single key type for "myhost" at a non-default port (2222), whose
+//     known_hosts entry uses the "[host]:port" format,
+//   - an entry for "other-host" that must never match "myhost" lookups,
+//   - a hashed entry (starting with "|1|") that must be silently skipped.
+func TestKnownHostAlgorithms(t *testing.T) {
+	config, err := ParseSSHConfig("testdata/config-known-hosts")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		hostAlias string
+		wantAlgos []string
+	}{
+		{
+			name:      "StandardPortTwoKeyTypes",
+			hostAlias: "myhost",
+			wantAlgos: []string{"ssh-ed25519", "ecdsa-sha2-nistp256"},
+		},
+		{
+			name:      "NonDefaultPortBracketNotation",
+			hostAlias: "myhost-port",
+			wantAlgos: []string{"ssh-rsa"},
+		},
+		{
+			name:      "StrictHostKeyCheckingNoReturnsNil",
+			hostAlias: "no-strict",
+			wantAlgos: nil,
+		},
+		{
+			name:      "NoMatchReturnsNil",
+			hostAlias: "nomatch",
+			wantAlgos: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.knownHostAlgorithms(tt.hostAlias)
+			if !slices.Equal(got, tt.wantAlgos) {
+				t.Errorf("knownHostAlgorithms(%q) = %v, want %v", tt.hostAlias, got, tt.wantAlgos)
+			}
+		})
+	}
+}
+
 // TestParseHostsRange covers numeric range expansion without consulting the
 // SSH config. Passing an empty configFile is safe here because no glob token
 // appears in any of the specs.

--- a/testdata/config-known-hosts
+++ b/testdata/config-known-hosts
@@ -1,0 +1,23 @@
+Host myhost
+    Hostname myhost
+    Port 22
+    UserKnownHostsFile testdata/known_hosts
+    StrictHostKeyChecking yes
+
+Host myhost-port
+    Hostname myhost
+    Port 2222
+    UserKnownHostsFile testdata/known_hosts
+    StrictHostKeyChecking yes
+
+Host no-strict
+    Hostname myhost
+    Port 22
+    UserKnownHostsFile testdata/known_hosts
+    StrictHostKeyChecking no
+
+Host nomatch
+    Hostname no-such-host
+    Port 22
+    UserKnownHostsFile testdata/known_hosts
+    StrictHostKeyChecking yes

--- a/testdata/known_hosts
+++ b/testdata/known_hosts
@@ -6,5 +6,5 @@ myhost ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBB
 [myhost]:2222 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCTESTKEYDATAFAKEabcdefghijklmnopqrstuvwxyz0123456789ABCDEFTEST==
 # A different host that must not match myhost lookups.
 other-host ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINONMATCHINGKEYabcdefghijklmnopqrstuvwxyzTEST
-# Hashed entry (must be skipped by the parser).
+# Hashed entry (matched via HMAC-SHA1 by matchesHashedHost).
 |1|abc123salt==|def456hash== ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHASHEDKEYabcdefghijklmnopqrstuvwxyzTEST

--- a/testdata/known_hosts
+++ b/testdata/known_hosts
@@ -1,0 +1,10 @@
+# Sample known_hosts for testing knownHostAlgorithms.
+# Standard-port host with two key types.
+myhost ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBqkSEFpXWQk7AJiHDi9bnMzxGJFzOtMkBvMa7VKTEST
+myhost ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBPTESTKEYDATAFAKEabcdefghijklmnopqrstuvwxyz0123456789ABCDEFTEST==
+# Non-default port entry (produces [host]:port normalization).
+[myhost]:2222 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCTESTKEYDATAFAKEabcdefghijklmnopqrstuvwxyz0123456789ABCDEFTEST==
+# A different host that must not match myhost lookups.
+other-host ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINONMATCHINGKEYabcdefghijklmnopqrstuvwxyzTEST
+# Hashed entry (must be skipped by the parser).
+|1|abc123salt==|def456hash== ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHASHEDKEYabcdefghijklmnopqrstuvwxyzTEST


### PR DESCRIPTION
Go's crypto/ssh prefers ECDSA over ED25519 by default. When a server
offers multiple host key types but only one is recorded in known_hosts,
the client negotiates a type the known_hosts file does not have,
causing knownhosts to find the hostname but report a key mismatch.

Add knownHostAlgorithms, which scans the known_hosts files for the
resolved address of a host alias and returns the recorded key types.
ClientConfig now sets HostKeyAlgorithms from this list so that the
client requests only key types already stored locally, matching the
behavior of OpenSSH.

This finally fixes #2 in iago, which was prematurely closed.

Fixes #2

