### PR TITLE
Support concurrent dialing in NewSSHGroup

### DIFF
--- a/iago.go
+++ b/iago.go
@@ -70,11 +70,52 @@ func GetIntVar(host Host, key string) int {
 	return 0
 }
 
+// GroupOption configures how [NewSSHGroup] dials hosts.
+type GroupOption func(*groupConfig)
+
+type groupConfig struct {
+	failFast        bool
+	dialConcurrency int
+}
+
+func applyGroupOptions(opts ...GroupOption) groupConfig {
+	var cfg groupConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}
+
+// FailFast returns a [GroupOption] that makes [NewSSHGroup] stop and return
+// an error if any dial fails. Without this option, [NewSSHGroup] collects
+// all dial errors in [Group.DialErrors] and returns only the successfully
+// connected hosts.
+func FailFast() GroupOption {
+	return func(cfg *groupConfig) {
+		cfg.failFast = true
+	}
+}
+
+// DialConcurrency returns a [GroupOption] that sets the maximum number of
+// target hosts dialed concurrently inside [NewSSHGroup]. Values less than 2
+// leave dialing sequential (the default). Jump connections are always
+// established sequentially before concurrent target dialing begins, so
+// there is at most one TCP connection to each jump host regardless of n.
+func DialConcurrency(n int) GroupOption {
+	return func(cfg *groupConfig) {
+		cfg.dialConcurrency = n
+	}
+}
+
 // Group is a group of hosts.
 type Group struct {
 	Hosts        []Host
 	ErrorHandler ErrorHandler
 	Timeout      time.Duration
+
+	// DialErrors holds per-alias dial failures from [NewSSHGroup] when
+	// [FailFast] is not set. A nil map means all aliases connected successfully.
+	DialErrors map[string]error
 
 	// sharedClosers are resources owned by the group rather than by any
 	// individual host (for example, a single SSH connection to a ProxyJump

--- a/iago.go
+++ b/iago.go
@@ -87,9 +87,11 @@ func applyGroupOptions(opts ...GroupOption) groupConfig {
 }
 
 // FailFast returns a [GroupOption] that makes [NewSSHGroup] stop and return
-// an error if any dial fails. Without this option, [NewSSHGroup] collects
-// all dial errors in [Group.DialErrors] and returns only the successfully
-// connected hosts.
+// an error if any dial fails. Targets that have not yet been dialed when the
+// first failure is observed are skipped; combined with [DialConcurrency] this
+// is best-effort, as dials already in flight still run to completion. Without
+// this option, [NewSSHGroup] collects all dial errors in [Group.DialErrors]
+// and returns only the successfully connected hosts.
 func FailFast() GroupOption {
 	return func(cfg *groupConfig) {
 		cfg.failFast = true

--- a/iagotest/ssh_group_test.go
+++ b/iagotest/ssh_group_test.go
@@ -331,17 +331,18 @@ func TestNewSSHGroupInvalidConfig(t *testing.T) {
 		t.Error("Expected error for non-existent config file, got nil")
 	}
 
-	// Test with invalid config file
+	// Test with malformed config content that the parser rejects. The
+	// ssh_config parser is lenient and accepts most junk, but a Match
+	// directive without criteria is one of the few inputs Decode errors on.
+	// Parsing happens before any dialing, so the error here must come from
+	// config parsing rather than from dialing test-host (no FailFast needed).
 	invalidConfigPath := filepath.Join(tmpDir, "invalid-config")
-	invalidConfig := "Invalid SSH Config Content\nNot a valid format"
-	if err := os.WriteFile(invalidConfigPath, []byte(invalidConfig), 0o600); err != nil {
+	if err := os.WriteFile(invalidConfigPath, []byte("Match\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	group, err := iago.NewSSHGroup([]string{"test-host"}, invalidConfigPath, iago.FailFast())
-	if err == nil {
-		group.Close()
-		t.Error("Expected error for unreachable host with FailFast, got nil")
+	if _, err := iago.NewSSHGroup([]string{"test-host"}, invalidConfigPath); err == nil {
+		t.Error("Expected error for malformed config content, got nil")
 	}
 }
 

--- a/iagotest/ssh_group_test.go
+++ b/iagotest/ssh_group_test.go
@@ -66,6 +66,22 @@ func (p *countingProxy) serve(target string) {
 	}
 }
 
+func unusedLocalTCPPort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	if closeErr := ln.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return port
+}
+
 func TestNewSSHGroup(t *testing.T) {
 	tmpDir := t.TempDir()
 	keyFiles := setupSSHKeys(t, tmpDir)
@@ -240,7 +256,7 @@ func TestNewSSHGroupProxyJump(t *testing.T) {
 		hostAliases[i] = tgt.hostAlias
 	}
 
-	group, err := iago.NewSSHGroup(hostAliases, configPath)
+	group, err := iago.NewSSHGroup(hostAliases, configPath, iago.DialConcurrency(numTargets))
 	if err != nil {
 		t.Fatalf("NewSSHGroup: %v", err)
 	}
@@ -271,6 +287,40 @@ func TestNewSSHGroupProxyJump(t *testing.T) {
 	})
 }
 
+func TestNewSSHGroupPartialDialErrors(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyFiles := setupSSHKeys(t, tmpDir)
+
+	cli, network := setupContainerEnvironment(t, true)
+	t.Cleanup(cleanupNetwork(t, cli, network))
+
+	reachable := createContainerWithInfo(t, cli, network, "reachable-host", keyFiles.signer)
+	t.Cleanup(cleanupContainer(t, cli, network, reachable.id))
+
+	configEntries := []string{
+		sshConfigEntry(reachable.hostAlias, "127.0.0.1", "root", keyFiles.privateKeyPath, reachable.port),
+		sshConfigEntry("unreachable-host", "127.0.0.1", "root", keyFiles.privateKeyPath, unusedLocalTCPPort(t)),
+	}
+	configPath := filepath.Join(tmpDir, "config")
+	createSSHConfigFile(t, configPath, configEntries)
+
+	group, err := iago.NewSSHGroup([]string{reachable.hostAlias, "unreachable-host"}, configPath)
+	if err != nil {
+		t.Fatalf("NewSSHGroup returned error despite one reachable host: %v", err)
+	}
+	defer group.Close()
+
+	if len(group.Hosts) != 1 {
+		t.Fatalf("group has %d hosts, want 1", len(group.Hosts))
+	}
+	if group.Hosts[0].Name() != reachable.hostAlias {
+		t.Errorf("host name = %q, want %q", group.Hosts[0].Name(), reachable.hostAlias)
+	}
+	if group.DialErrors["unreachable-host"] == nil {
+		t.Error("Expected dial error for unreachable-host in group.DialErrors, got nil")
+	}
+}
+
 func TestNewSSHGroupInvalidConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -288,9 +338,10 @@ func TestNewSSHGroupInvalidConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = iago.NewSSHGroup([]string{"test-host"}, invalidConfigPath)
+	group, err := iago.NewSSHGroup([]string{"test-host"}, invalidConfigPath, iago.FailFast())
 	if err == nil {
-		t.Error("Expected error for invalid config file, got nil")
+		group.Close()
+		t.Error("Expected error for unreachable host with FailFast, got nil")
 	}
 }
 
@@ -325,9 +376,17 @@ func TestNewSSHGroupUnknownHost(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Try to create group with unknown host
+	// By default, dial failures are stored in group.DialErrors when at least
+	// one host connects. If every requested host fails, NewSSHGroup returns an
+	// error instead of an empty group.
 	_, err := iago.NewSSHGroup([]string{"unknown-host"}, configPath)
 	if err == nil {
-		t.Error("Expected error for unknown host, got nil")
+		t.Error("Expected error when all requested hosts fail to dial, got nil")
+	}
+
+	// With FailFast, the same failure is returned directly from NewSSHGroup.
+	_, err = iago.NewSSHGroup([]string{"unknown-host"}, configPath, iago.FailFast())
+	if err == nil {
+		t.Error("Expected error from NewSSHGroup with FailFast for unknown host, got nil")
 	}
 }

--- a/ssh.go
+++ b/ssh.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/pkg/sftp"
 	"github.com/relab/iago/sftpfs"
@@ -98,79 +98,270 @@ func newHostFromClient(name string, client *ssh.Client) (Host, error) {
 // This mirrors what OpenSSH's ControlMaster provides for the system ssh client and
 // avoids opening one proxy connection per target alias. The shared jump clients are
 // owned by the returned [Group] and closed by [Group.Close].
-func NewSSHGroup(hostAliases []string, sshConfigFile string) (group Group, err error) {
-	if sshConfigFile == "" {
-		if err = initHomeDir(); err != nil {
-			return group, err
-		}
-		sshConfigFile = filepath.Join(homeDir, ".ssh", "config")
+//
+// By default, dial failures are collected in [Group.DialErrors] instead of
+// aborting the call. If no hosts connect successfully, an error is returned.
+// Pass [FailFast] to return an error if any target fails. Pass [DialConcurrency]
+// to dial target hosts concurrently; jump connections are always established
+// sequentially first so at most one TCP connection is made to each jump host.
+func NewSSHGroup(hostAliases []string, sshConfigFile string, opts ...GroupOption) (group Group, err error) {
+	cfg := applyGroupOptions(opts...)
+	sshConfigFile, err = resolveSSHConfigFile(sshConfigFile)
+	if err != nil {
+		return group, err
 	}
 	config, err := ParseSSHConfig(sshConfigFile)
 	if err != nil {
 		return group, err
 	}
 
-	jumpClients := make(map[string]*ssh.Client)
-	hosts := make([]Host, 0, len(hostAliases))
-	defer func() {
-		if err == nil {
-			return
-		}
-		for _, h := range hosts {
-			_ = h.Close()
-		}
-		for _, jc := range jumpClients {
-			_ = jc.Close()
-		}
-	}()
+	dialer := newGroupDialer(config, hostAliases)
+	defer dialer.closeOnError(&err)
 
-	for _, alias := range hostAliases {
-		var host Host
-		host, err = dialHost(alias, config, jumpClients)
-		if err != nil {
+	if err = dialer.prepareJumps(cfg.failFast); err != nil {
+		return group, err
+	}
+	dialer.dialAll(cfg.dialConcurrency)
+	if cfg.failFast {
+		if err = dialer.firstDialError(); err != nil {
 			return group, err
 		}
-		hosts = append(hosts, host)
 	}
-
-	group = NewGroup(hosts)
-	for _, jc := range jumpClients {
-		group.sharedClosers = append(group.sharedClosers, jc)
+	if err = dialer.allFailedError(); err != nil {
+		return group, err
 	}
-	return group, nil
+	return dialer.group(), nil
 }
 
-// dialHost dials a single host using the given SSH config. If the host has a
-// ProxyJump, jumpClients is consulted first: if a client for that proxy spec
-// already exists it is reused, otherwise a new connection to the proxy is
-// dialed and stored in the map. The map is the caller's responsibility to
-// close (typically via [Group.sharedClosers]).
-func dialHost(alias string, config *sshConfig, jumpClients map[string]*ssh.Client) (Host, error) {
+// groupDialer assembles a [Group] by dialing a set of host aliases under a single
+// SSH config, sharing one connection per distinct ProxyJump spec.
+//
+// Its lifecycle has two phases separated by a deliberate concurrency boundary:
+//
+//  1. prepareJumps establishes the shared jump connections. This is the only
+//     phase that writes jumpClients and jumpErrs.
+//  2. dialAll dials the target hosts, optionally in parallel. Its workers only
+//     read the jump maps (through jumpFor), so the read-only boundary holds by
+//     construction and no locking is required.
+//
+// The dialer owns every connection it opens until [groupDialer.group] transfers
+// ownership to the returned Group; on any earlier error, [groupDialer.closeOnError]
+// closes them all.
+type groupDialer struct {
+	config      *sshConfig
+	aliases     []string
+	jumpClients map[string]*ssh.Client // proxy spec -> shared jump connection
+	jumpErrs    map[string]error       // proxy spec -> error establishing it
+	hosts       []Host                 // successfully dialed targets
+	dialErrs    map[string]error       // alias -> dial error; nil until first failure
+}
+
+func newGroupDialer(config *sshConfig, aliases []string) *groupDialer {
+	return &groupDialer{
+		config:      config,
+		aliases:     aliases,
+		jumpClients: make(map[string]*ssh.Client),
+		jumpErrs:    make(map[string]error),
+	}
+}
+
+// prepareJumps establishes one shared connection per distinct ProxyJump spec
+// referenced by the aliases. With failFast set, the first failure is returned
+// immediately; otherwise failures are recorded per spec and later surfaced as
+// the dial error of every alias routing through that jump (see [groupDialer.jumpFor]).
+func (d *groupDialer) prepareJumps(failFast bool) error {
+	for _, alias := range d.aliases {
+		proxySpec, err := d.config.get(alias, "ProxyJump")
+		if err != nil || proxySpec == "" || proxySpec == "none" {
+			continue
+		}
+		if _, ok := d.jumpClients[proxySpec]; ok {
+			continue
+		}
+		if _, ok := d.jumpErrs[proxySpec]; ok {
+			continue
+		}
+		client, err := dialJump(proxySpec, d.config)
+		if err != nil {
+			if failFast {
+				return err
+			}
+			d.jumpErrs[proxySpec] = err
+			continue
+		}
+		d.jumpClients[proxySpec] = client
+	}
+	return nil
+}
+
+// jumpFor resolves the shared jump connection for alias. It returns (nil, nil)
+// when alias connects directly, (client, nil) when it routes through an
+// established jump, or (nil, err) when its jump could not be established. It only
+// reads state populated by prepareJumps, so it is safe for concurrent callers.
+func (d *groupDialer) jumpFor(alias string) (*ssh.Client, error) {
+	proxySpec, err := d.config.get(alias, "ProxyJump")
+	if err != nil {
+		return nil, err
+	}
+	if proxySpec == "" || proxySpec == "none" {
+		return nil, nil
+	}
+	if err := d.jumpErrs[proxySpec]; err != nil {
+		return nil, err
+	}
+	client := d.jumpClients[proxySpec]
+	if client == nil {
+		// prepareJumps establishes every referenced spec, so a missing client
+		// signals a programming error rather than a connection failure.
+		return nil, fmt.Errorf("iago: proxy jump %q was not prepared", proxySpec)
+	}
+	return client, nil
+}
+
+// dialAll dials every alias, reusing shared jump connections, and records the
+// outcomes in hosts and dialErrs. Up to concurrency aliases are dialed in
+// parallel; a value below 2 dials sequentially.
+func (d *groupDialer) dialAll(concurrency int) {
+	if len(d.aliases) == 0 {
+		return
+	}
+	results := make([]sshDialResult, len(d.aliases))
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	for range dialConcurrency(concurrency, len(d.aliases)) {
+		wg.Go(func() {
+			for i := range jobs {
+				results[i] = d.dialOne(d.aliases[i])
+			}
+		})
+	}
+	for i := range d.aliases {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+	d.collect(results)
+}
+
+// dialOne dials a single alias through its shared jump connection, if any.
+func (d *groupDialer) dialOne(alias string) sshDialResult {
+	jump, err := d.jumpFor(alias)
+	if err != nil {
+		return sshDialResult{err: err}
+	}
+	host, err := dialTarget(alias, d.config, jump)
+	return sshDialResult{host: host, err: err}
+}
+
+// collect records per-alias results in aliases order, lazily allocating dialErrs
+// so it stays nil when every alias connects.
+func (d *groupDialer) collect(results []sshDialResult) {
+	d.hosts = make([]Host, 0, len(results))
+	for i, alias := range d.aliases {
+		if results[i].host != nil {
+			d.hosts = append(d.hosts, results[i].host)
+		}
+		if results[i].err != nil {
+			if d.dialErrs == nil {
+				d.dialErrs = make(map[string]error)
+			}
+			d.dialErrs[alias] = results[i].err
+		}
+	}
+}
+
+// firstDialError returns the dial error of the earliest alias that failed, or nil
+// if all connected. It is used to honor [FailFast].
+func (d *groupDialer) firstDialError() error {
+	for _, alias := range d.aliases {
+		if err := d.dialErrs[alias]; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// allFailedError returns a combined error when no alias connected, or nil if at
+// least one did (or none were requested).
+func (d *groupDialer) allFailedError() error {
+	if len(d.hosts) > 0 || len(d.dialErrs) == 0 {
+		return nil
+	}
+	errs := make([]error, 0, len(d.dialErrs))
+	for _, alias := range d.aliases {
+		if err := d.dialErrs[alias]; err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", alias, err))
+		}
+	}
+	return fmt.Errorf("iago: failed to dial any hosts: %w", errors.Join(errs...))
+}
+
+// group transfers ownership of the dialed hosts and shared jump connections to a
+// new [Group]. After this call the dialer no longer owns those connections, so it
+// must only run on the success path where closeOnError is a no-op.
+func (d *groupDialer) group() Group {
+	group := NewGroup(d.hosts)
+	group.DialErrors = d.dialErrs
+	for _, jc := range d.jumpClients {
+		group.sharedClosers = append(group.sharedClosers, jc)
+	}
+	return group
+}
+
+// closeOnError closes every connection the dialer opened when *errPtr is non-nil.
+// It is a no-op on success, where ownership has passed to the returned Group.
+func (d *groupDialer) closeOnError(errPtr *error) {
+	if *errPtr == nil {
+		return
+	}
+	for _, h := range d.hosts {
+		_ = h.Close()
+	}
+	for _, jc := range d.jumpClients {
+		_ = jc.Close()
+	}
+}
+
+type sshDialResult struct {
+	host Host
+	err  error
+}
+
+func dialConcurrency(concurrency, aliases int) int {
+	if concurrency < 2 {
+		return 1
+	}
+	return min(concurrency, aliases)
+}
+
+// dialJump establishes a new SSH connection to the given ProxyJump spec. The
+// returned client is a bare [ssh.Client] used only as a tunnel; unlike a target
+// host it has no SFTP sub-client or fetched environment.
+func dialJump(proxySpec string, config *sshConfig) (*ssh.Client, error) {
+	jumpCfg, err := config.ClientConfig(proxySpec)
+	if err != nil {
+		return nil, fmt.Errorf("proxy jump %q: %w", proxySpec, err)
+	}
+	client, err := ssh.Dial("tcp", config.ConnectAddr(proxySpec), jumpCfg)
+	if err != nil {
+		return nil, fmt.Errorf("dial proxy jump %q: %w", proxySpec, err)
+	}
+	return client, nil
+}
+
+// dialTarget dials a single target alias. When jump is non-nil the connection is
+// tunnelled through that shared jump client; otherwise it is dialed directly. The
+// jump client's lifetime is managed by the caller, not by the returned Host.
+func dialTarget(alias string, config *sshConfig, jump *ssh.Client) (Host, error) {
 	clientCfg, err := config.ClientConfig(alias)
 	if err != nil {
 		return nil, err
 	}
-	proxySpec, err := config.get(alias, "ProxyJump")
-	if err != nil {
-		return nil, err
+	addr := config.ConnectAddr(alias)
+	if jump == nil {
+		return DialSSH(alias, addr, clientCfg)
 	}
-	targetAddr := config.ConnectAddr(alias)
-	if proxySpec == "" || proxySpec == "none" {
-		return DialSSH(alias, targetAddr, clientCfg)
-	}
-	jumpClient, ok := jumpClients[proxySpec]
-	if !ok {
-		jumpCfg, err := config.ClientConfig(proxySpec)
-		if err != nil {
-			return nil, fmt.Errorf("proxy jump %q for %q: %w", proxySpec, alias, err)
-		}
-		jumpClient, err = ssh.Dial("tcp", config.ConnectAddr(proxySpec), jumpCfg)
-		if err != nil {
-			return nil, fmt.Errorf("dial proxy jump %q: %w", proxySpec, err)
-		}
-		jumpClients[proxySpec] = jumpClient
-	}
-	return dialViaProxy(alias, targetAddr, clientCfg, jumpClient)
+	return dialViaProxy(alias, addr, clientCfg, jump)
 }
 
 // fetchEnv returns a map containing the environment variables of the ssh server.

--- a/ssh.go
+++ b/ssh.go
@@ -118,16 +118,10 @@ func NewSSHGroup(hostAliases []string, sshConfigFile string, opts ...GroupOption
 	dialer := newGroupDialer(config, hostAliases)
 	defer dialer.closeOnError(&err)
 
-	if err = dialer.prepareJumps(cfg.failFast); err != nil {
+	if err = dialer.prepareJumps(cfg); err != nil {
 		return group, err
 	}
-	dialer.dialAll(cfg.dialConcurrency)
-	if cfg.failFast {
-		if err = dialer.firstDialError(); err != nil {
-			return group, err
-		}
-	}
-	if err = dialer.allFailedError(); err != nil {
+	if err = dialer.dialAll(cfg); err != nil {
 		return group, err
 	}
 	return dialer.group(), nil
@@ -166,10 +160,10 @@ func newGroupDialer(config *sshConfig, aliases []string) *groupDialer {
 }
 
 // prepareJumps establishes one shared connection per distinct ProxyJump spec
-// referenced by the aliases. With failFast set, the first failure is returned
+// referenced by the aliases. With [FailFast] set, the first failure is returned
 // immediately; otherwise failures are recorded per spec and later surfaced as
 // the dial error of every alias routing through that jump (see [groupDialer.jumpFor]).
-func (d *groupDialer) prepareJumps(failFast bool) error {
+func (d *groupDialer) prepareJumps(cfg groupConfig) error {
 	for _, alias := range d.aliases {
 		proxySpec, err := d.config.get(alias, "ProxyJump")
 		if err != nil || proxySpec == "" || proxySpec == "none" {
@@ -183,7 +177,7 @@ func (d *groupDialer) prepareJumps(failFast bool) error {
 		}
 		client, err := dialJump(proxySpec, d.config)
 		if err != nil {
-			if failFast {
+			if cfg.failFast {
 				return err
 			}
 			d.jumpErrs[proxySpec] = err
@@ -218,29 +212,56 @@ func (d *groupDialer) jumpFor(alias string) (*ssh.Client, error) {
 	return client, nil
 }
 
-// dialAll dials every alias, reusing shared jump connections, and records the
-// outcomes in hosts and dialErrs. Up to concurrency aliases are dialed in
-// parallel; a value below 2 dials sequentially.
-func (d *groupDialer) dialAll(concurrency int) {
+// dialAll dials every alias, reusing shared jump connections, records the
+// outcomes in hosts and dialErrs, and reports the first fatal error: with
+// [FailFast] the earliest failing alias's dial error, otherwise a combined
+// error only when no alias connected at all. Up to cfg.dialConcurrency aliases
+// are dialed in parallel; a value below 2 dials sequentially.
+//
+// With [FailFast] set, the first failed dial stops further targets from being
+// queued: sequentially this means no later alias is contacted at all, while
+// concurrently it is best-effort because dials already in flight still run to
+// completion (a direct [DialSSH] cannot be cancelled mid-handshake).
+func (d *groupDialer) dialAll(cfg groupConfig) error {
 	if len(d.aliases) == 0 {
-		return
+		return nil
 	}
 	results := make([]sshDialResult, len(d.aliases))
 	jobs := make(chan int)
+	abort := make(chan struct{})
+	var abortOnce sync.Once
 	var wg sync.WaitGroup
-	for range dialConcurrency(concurrency, len(d.aliases)) {
+	for range dialConcurrency(cfg.dialConcurrency, len(d.aliases)) {
 		wg.Go(func() {
 			for i := range jobs {
 				results[i] = d.dialOne(d.aliases[i])
+				if cfg.failFast && results[i].err != nil {
+					// Signal the scheduler to stop queuing further targets and
+					// stop this worker from picking up any already-queued one.
+					abortOnce.Do(func() { close(abort) })
+					return
+				}
 			}
 		})
 	}
+schedule:
 	for i := range d.aliases {
-		jobs <- i
+		select {
+		case <-abort:
+			break schedule
+		case jobs <- i:
+		}
 	}
 	close(jobs)
 	wg.Wait()
 	d.collect(results)
+
+	if cfg.failFast {
+		if err := d.firstDialError(); err != nil {
+			return err
+		}
+	}
+	return d.allFailedError()
 }
 
 // dialOne dials a single alias through its shared jump connection, if any.

--- a/ssh_config.go
+++ b/ssh_config.go
@@ -66,6 +66,21 @@ func ParseSSHConfig(configFile string) (*sshConfig, error) {
 	return &sshConfig{decodedConfig}, nil
 }
 
+// resolveSSHConfigFile returns the path to the SSH config file to use, based
+// on the provided sshConfigFile argument. If sshConfigFile is non-empty, it is
+// returned as is. Otherwise, the default path ~/.ssh/config is returned.
+// An error is returned if the home directory cannot be determined when needed
+// to resolve the default path.
+func resolveSSHConfigFile(sshConfigFile string) (string, error) {
+	if sshConfigFile != "" {
+		return sshConfigFile, nil
+	}
+	if err := initHomeDir(); err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, ".ssh", "config"), nil
+}
+
 type sshConfig struct {
 	config *ssh_config.Config
 }
@@ -379,13 +394,11 @@ func ParseHosts(spec, configFile string) ([]string, error) {
 			// Lazy-load the SSH config only if we encounter a glob token, to avoid
 			// unnecessary parsing. We only need to parse once; hence the nil check.
 			if config == nil {
-				if configFile == "" {
-					if err := initHomeDir(); err != nil {
-						return nil, err
-					}
-					configFile = filepath.Join(homeDir, ".ssh", "config")
-				}
 				var err error
+				configFile, err = resolveSSHConfigFile(configFile)
+				if err != nil {
+					return nil, err
+				}
 				config, err = ParseSSHConfig(configFile)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
By default, NewSSHGroup no longer aborts on the first dial failure. It returns the hosts that connected and records the rest in the new Group.DialErrors map, returning an error only when no host connects.

Add functional options to control this:
  - FailFast()        restore the previous abort-on-first-error behavior
  - DialConcurrency(n) dial up to n target hosts concurrently (default: 1)

Restructure the dial internals around a single groupDialer type that owns the SSH config and the shared-jump/dial-error state. Orchestration lives on the type; the low-level dialing stays in stateless helpers (dialTarget, dialJump).

Shared ProxyJump connections are established once, before target dialing begins. The concurrent dial phase is read-only over the jump state, so it is safe by construction with no locking: prepareJumps is the only writer and completes before any worker starts.
