### PR TITLE
Add support for agent forwarding and keep alive options

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
         "iagotest",
         "jumpbox",
         "jumpuser",
+        "keepalives",
         "kevinburke",
         "keygen",
         "knownhosts",

--- a/README.md
+++ b/README.md
@@ -39,11 +39,28 @@ g.ErrorHandler = func(e error) {
 }
 ```
 
+## Agent forwarding and keepalives
+
+Pass `iago.ForwardAgent()` to `NewSSHGroup` to forward the local SSH agent to every
+host in the group, regardless of the `ForwardAgent` setting in the SSH config file —
+equivalent to `ssh -A`. This lets a remote host authenticate onward to other hosts
+using the caller's local agent, for example when a driver node SSHes into peer nodes.
+Forwarding can also be enabled per host via `ForwardAgent yes` in the SSH config file.
+
+Pass `iago.KeepAlive(interval)` to send a periodic SSH keepalive on every dialed
+connection, so an idle connection (for example, a control channel streaming a long,
+quiet remote run) is not silently dropped by a NAT or firewall idle timeout:
+
+```go
+g, err := iago.NewSSHGroup(hosts, configPath, iago.ForwardAgent(), iago.KeepAlive(30*time.Second))
+```
+
 ## SSH config files
 
 `iago.NewSSHGroup` reads an OpenSSH-style config file (defaulting to `~/.ssh/config`).
 It honours the following per-host options: `Hostname`, `Port`, `User`, `IdentityFile`,
-`ProxyJump`, `ConnectTimeout`, `StrictHostKeyChecking`, and `UserKnownHostsFile`.
+`ProxyJump`, `ConnectTimeout`, `StrictHostKeyChecking`, `UserKnownHostsFile`, and
+`ForwardAgent`.
 OpenSSH's **first-match-wins** rule applies: the first `Host` stanza that matches a given
 alias wins for each option.
 

--- a/fs.go
+++ b/fs.go
@@ -123,6 +123,10 @@ func (u Upload) Apply(ctx context.Context, host Host) error {
 }
 
 // Download downloads a file or directory from a remote host.
+// For each host in a group, a subdirectory named after the host is created
+// under Dest so that results from multiple hosts do not collide.
+// Use DownloadDir when you are downloading from a single host and want the
+// remote directory's contents placed directly into the local destination.
 type Download struct {
 	Src  Path
 	Dest Path
@@ -132,6 +136,67 @@ type Download struct {
 // Apply performs the download.
 func (d Download) Apply(ctx context.Context, host Host) error {
 	return copyAction{src: d.Src, dest: d.Dest, perm: d.Perm, fetch: true}.Apply(ctx, host)
+}
+
+// ProgressFunc is called during a file transfer to report incremental progress.
+// n is the number of bytes just transferred.
+type ProgressFunc func(n int64)
+
+// DownloadDir downloads the contents of a remote directory directly into a
+// local destination via SFTP, without adding a per-host subdirectory. Use
+// this instead of Download when fetching from a single host and direct
+// placement is desired. Progress, if non-nil, is called with each chunk of
+// bytes transferred.
+type DownloadDir struct {
+	Src      Path
+	Dest     Path
+	Progress ProgressFunc
+}
+
+// Apply downloads the contents of d.Src on host into d.Dest.
+func (d DownloadDir) Apply(_ context.Context, host Host) error {
+	from, err := fs.Sub(host.GetFS(), removeSlash(d.Src.prefix))
+	if err != nil {
+		return err
+	}
+	to := fs.DirFS(d.Dest.prefix)
+	return copyDir(d.Src.path, d.Dest.path, Perm{}, from, to, d.Progress)
+}
+
+// Size returns the total byte count of all files under d.Src on host.
+// Directory metadata is not counted. Call this before Apply to obtain the
+// total for progress display.
+func (d DownloadDir) Size(_ context.Context, host Host) (int64, error) {
+	from, err := fs.Sub(host.GetFS(), removeSlash(d.Src.prefix))
+	if err != nil {
+		return 0, err
+	}
+	return totalSize(from, d.Src.path)
+}
+
+func totalSize(fsys fs.FS, dir string) (int64, error) {
+	entries, err := fs.ReadDir(fsys, dir)
+	if err != nil {
+		return 0, err
+	}
+	var total int64
+	for _, e := range entries {
+		p := path.Join(dir, e.Name())
+		if e.IsDir() {
+			n, err := totalSize(fsys, p)
+			if err != nil {
+				return total, err
+			}
+			total += n
+		} else {
+			info, err := e.Info()
+			if err != nil {
+				return total, err
+			}
+			total += info.Size()
+		}
+	}
+	return total, nil
 }
 
 type copyAction struct {
@@ -171,17 +236,17 @@ func (ca copyAction) Apply(_ context.Context, host Host) (err error) {
 			// since we might be copying from multiple hosts, we will create a subdirectory in the destination folder
 			dest = filepath.Join(dest, host.Name())
 		}
-		return copyDir(ca.src.path, dest, ca.perm, from, to)
+		return copyDir(ca.src.path, dest, ca.perm, from, to, nil)
 	}
 	dest := ca.dest.path
 	if ca.fetch {
 		// since we might be copying from multiple hosts, we add the host's name to the destination file
 		dest += "." + host.Name()
 	}
-	return copyFile(ca.src.path, dest, ca.perm, from, to)
+	return copyFile(ca.src.path, dest, ca.perm, from, to, nil)
 }
 
-func copyDir(src, dest string, perm Perm, from, to fs.FS) error {
+func copyDir(src, dest string, perm Perm, from, to fs.FS, progress ProgressFunc) error {
 	files, err := fs.ReadDir(from, src)
 	if err != nil {
 		return err
@@ -194,9 +259,9 @@ func copyDir(src, dest string, perm Perm, from, to fs.FS) error {
 
 	for _, info := range files {
 		if info.IsDir() {
-			err = copyDir(path.Join(src, info.Name()), path.Join(dest, info.Name()), perm, from, to)
+			err = copyDir(path.Join(src, info.Name()), path.Join(dest, info.Name()), perm, from, to, progress)
 		} else {
-			err = copyFile(path.Join(src, info.Name()), path.Join(dest, info.Name()), perm, from, to)
+			err = copyFile(path.Join(src, info.Name()), path.Join(dest, info.Name()), perm, from, to, progress)
 		}
 		if err != nil {
 			return err
@@ -205,7 +270,7 @@ func copyDir(src, dest string, perm Perm, from, to fs.FS) error {
 	return nil
 }
 
-func copyFile(src, dest string, perm Perm, from fs.FS, to fs.FS) (err error) {
+func copyFile(src, dest string, perm Perm, from fs.FS, to fs.FS, progress ProgressFunc) (err error) {
 	fromF, err := from.Open(src)
 	if err != nil {
 		return err
@@ -223,6 +288,23 @@ func copyFile(src, dest string, perm Perm, from fs.FS, to fs.FS) (err error) {
 		return fmt.Errorf("cannot write to %s: %w", dest, fs.ErrUnsupported)
 	}
 
-	_, err = io.Copy(writer, fromF)
+	var r io.Reader = fromF
+	if progress != nil {
+		r = &progressReader{r: fromF, fn: progress}
+	}
+	_, err = io.Copy(writer, r)
 	return err
+}
+
+type progressReader struct {
+	r  io.Reader
+	fn ProgressFunc
+}
+
+func (pr *progressReader) Read(p []byte) (int, error) {
+	n, err := pr.r.Read(p)
+	if n > 0 {
+		pr.fn(int64(n))
+	}
+	return n, err
 }

--- a/iago.go
+++ b/iago.go
@@ -74,9 +74,10 @@ func GetIntVar(host Host, key string) int {
 type GroupOption func(*groupConfig)
 
 type groupConfig struct {
-	failFast        bool
-	dialConcurrency int
-	forwardAgent    bool
+	failFast          bool
+	dialConcurrency   int
+	forwardAgent      bool
+	keepAliveInterval time.Duration
 }
 
 func applyGroupOptions(opts ...GroupOption) groupConfig {
@@ -107,6 +108,20 @@ func FailFast() GroupOption {
 func DialConcurrency(n int) GroupOption {
 	return func(cfg *groupConfig) {
 		cfg.dialConcurrency = n
+	}
+}
+
+// KeepAlive returns a [GroupOption] that sends an SSH keepalive request on every
+// dialed connection every interval. golang.org/x/crypto/ssh does not honor the
+// OpenSSH ServerAliveInterval config directive, so without this a connection
+// left idle (for example, a control channel streaming a long, quiet remote run)
+// can be silently dropped by a NAT or firewall idle timeout. The periodic
+// traffic keeps the mapping alive; if a keepalive fails, the connection is
+// closed so any in-flight session unblocks promptly instead of hanging. An
+// interval of zero or less disables keepalives (the default).
+func KeepAlive(interval time.Duration) GroupOption {
+	return func(cfg *groupConfig) {
+		cfg.keepAliveInterval = interval
 	}
 }
 

--- a/iago.go
+++ b/iago.go
@@ -76,6 +76,7 @@ type GroupOption func(*groupConfig)
 type groupConfig struct {
 	failFast        bool
 	dialConcurrency int
+	forwardAgent    bool
 }
 
 func applyGroupOptions(opts ...GroupOption) groupConfig {
@@ -106,6 +107,18 @@ func FailFast() GroupOption {
 func DialConcurrency(n int) GroupOption {
 	return func(cfg *groupConfig) {
 		cfg.dialConcurrency = n
+	}
+}
+
+// ForwardAgent returns a [GroupOption] that forces SSH agent forwarding for
+// every host in the group, regardless of the ForwardAgent setting in the SSH
+// config. This is equivalent to passing -A to the ssh command-line tool:
+// each session opened on a dialed host will request agent forwarding so that
+// the remote process can authenticate onward to other hosts using the
+// local agent.
+func ForwardAgent() GroupOption {
+	return func(cfg *groupConfig) {
+		cfg.forwardAgent = true
 	}
 }
 

--- a/iago.go
+++ b/iago.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"sync"
 	"time"
 
 	fs "github.com/relab/wrfs"
@@ -185,11 +186,18 @@ func (g Group) Run(name string, f func(context.Context, Host) error) {
 
 // Close closes any connections to hosts and any group-owned shared resources
 // (such as ProxyJump connections shared across hosts in this group).
-func (g Group) Close() (err error) {
-	for _, h := range g.Hosts {
-		// Join close errors; nil errors are discarded by Join.
-		err = errors.Join(err, h.Close())
+// Hosts are closed concurrently; shared resources (e.g. ProxyJump clients)
+// are closed sequentially after all hosts have been closed.
+func (g Group) Close() error {
+	errs := make([]error, len(g.Hosts))
+	var wg sync.WaitGroup
+	for i, h := range g.Hosts {
+		wg.Go(func() {
+			errs[i] = h.Close()
+		})
 	}
+	wg.Wait()
+	err := errors.Join(errs...)
 	for _, c := range g.sharedClosers {
 		err = errors.Join(err, c.Close())
 	}

--- a/iagotest/agent_forward_test.go
+++ b/iagotest/agent_forward_test.go
@@ -1,0 +1,107 @@
+package iagotest
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/relab/iago"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+// startTestAgent serves an in-process SSH agent holding the test key on a
+// unix socket and points SSH_AUTH_SOCK at it, so NewSSHGroup both
+// authenticates with the key (agent signers) and forwards this agent to the
+// dialed hosts when ForwardAgent is set.
+func startTestAgent(t *testing.T, privateKeyPath string) {
+	t.Helper()
+	pemBytes, err := os.ReadFile(privateKeyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawKey, err := ssh.ParseRawPrivateKey(pemBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyring := agent.NewKeyring()
+	if err := keyring.Add(agent.AddedKey{PrivateKey: rawKey}); err != nil {
+		t.Fatal(err)
+	}
+	// A dedicated short-path dir: unix socket paths are length-limited
+	// (~104 bytes on macOS) and t.TempDir can exceed that under long test names.
+	sockDir, err := os.MkdirTemp("", "iago-agent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+	sock := filepath.Join(sockDir, "a.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() { _ = agent.ServeAgent(keyring, conn) }()
+		}
+	}()
+	t.Setenv("SSH_AUTH_SOCK", sock)
+}
+
+// TestForwardAgentConnectionWideGrant verifies iago's once-per-connection
+// agent forwarding model against a real sshd: with ForwardAgent set, only the
+// first session sends auth-agent-req (OpenSSH grants it at most once per
+// connection), and a later session — which sends no request of its own — must
+// still see the connection-wide SSH_AUTH_SOCK and reach the forwarded agent
+// through it.
+func TestForwardAgentConnectionWideGrant(t *testing.T) {
+	tmpDir := t.TempDir()
+	keyFiles := setupSSHKeys(t, tmpDir)
+	startTestAgent(t, keyFiles.privateKeyPath)
+
+	cli, network := setupContainerEnvironment(t, true)
+	t.Cleanup(cleanupNetwork(t, cli, network))
+	info := createContainerWithInfo(t, cli, network, "agent-fwd-host", keyFiles.signer)
+	t.Cleanup(cleanupContainer(t, cli, network, info.id))
+
+	configPath := filepath.Join(tmpDir, "config")
+	createSSHConfigFile(t, configPath, []string{
+		sshConfigEntry(info.hostAlias, "127.0.0.1", "root", keyFiles.privateKeyPath, info.port),
+	})
+
+	group, err := iago.NewSSHGroup([]string{info.hostAlias}, configPath, iago.ForwardAgent())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer group.Close()
+	host := group.Hosts[0]
+
+	// Two sequential sessions on the same connection: the first is granted
+	// forwarding; the second inherits the connection-wide grant.
+	for _, session := range []string{"first", "second"} {
+		var sb strings.Builder
+		err := iago.Shell{
+			Command: `echo "SOCK=${SSH_AUTH_SOCK:-MISSING}"; ssh-add -l`,
+			Stdout:  &sb,
+			Stderr:  &sb,
+		}.Apply(context.Background(), host)
+		out := sb.String()
+		if err != nil {
+			t.Fatalf("%s session: %v\noutput:\n%s", session, err, out)
+		}
+		if strings.Contains(out, "SOCK=MISSING") {
+			t.Errorf("%s session: SSH_AUTH_SOCK not set\noutput:\n%s", session, out)
+		}
+		if !strings.Contains(out, "ED25519") {
+			t.Errorf("%s session: forwarded agent did not list the test key\noutput:\n%s", session, out)
+		}
+	}
+}

--- a/keepalive_test.go
+++ b/keepalive_test.go
@@ -1,0 +1,120 @@
+package iago
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakePinger records SendRequest calls and returns a configurable error, so the
+// keepalive loop can be exercised without a live SSH connection.
+type fakePinger struct {
+	mu    sync.Mutex
+	calls int
+	err   error
+}
+
+func (f *fakePinger) SendRequest(name string, wantReply bool, payload []byte) (bool, []byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return false, nil, f.err
+}
+
+func (f *fakePinger) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func TestKeepAliveOption(t *testing.T) {
+	if got := applyGroupOptions(KeepAlive(30 * time.Second)).keepAliveInterval; got != 30*time.Second {
+		t.Errorf("keepAliveInterval = %v, want 30s", got)
+	}
+	if got := applyGroupOptions().keepAliveInterval; got != 0 {
+		t.Errorf("default keepAliveInterval = %v, want 0", got)
+	}
+}
+
+// TestKeepAliveLoopOnDead verifies that a failing ping invokes onDead once and
+// stops the loop, so a dead connection is torn down instead of hanging.
+func TestKeepAliveLoopOnDead(t *testing.T) {
+	p := &fakePinger{err: errors.New("connection dead")}
+	tick := make(chan time.Time)
+	done := make(chan struct{})
+	dead := make(chan struct{}, 1)
+	finished := make(chan struct{})
+	go func() {
+		keepAliveLoop(p, tick, func() { dead <- struct{}{} }, done)
+		close(finished)
+	}()
+
+	tick <- time.Now()
+	select {
+	case <-dead:
+	case <-time.After(time.Second):
+		t.Fatal("onDead not called after ping failure")
+	}
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("loop did not return after ping failure")
+	}
+}
+
+// TestKeepAliveLoopStopsOnDone verifies that closing done stops the loop without
+// reporting the connection dead.
+func TestKeepAliveLoopStopsOnDone(t *testing.T) {
+	p := &fakePinger{}
+	tick := make(chan time.Time)
+	done := make(chan struct{})
+	var deadCalled bool
+	finished := make(chan struct{})
+	go func() {
+		keepAliveLoop(p, tick, func() { deadCalled = true }, done)
+		close(finished)
+	}()
+
+	close(done)
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("loop did not return after done closed")
+	}
+	if deadCalled {
+		t.Error("onDead should not be called on a clean stop")
+	}
+}
+
+// TestKeepAliveLoopPingsUntilStopped verifies that successful pings keep the loop
+// running across multiple ticks until done is closed.
+func TestKeepAliveLoopPingsUntilStopped(t *testing.T) {
+	p := &fakePinger{}
+	tick := make(chan time.Time)
+	done := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		keepAliveLoop(p, tick, nil, done)
+		close(finished)
+	}()
+
+	// Each send returns only after the loop receives the previous tick, so two
+	// successful sends prove the loop kept running rather than exiting early.
+	tick <- time.Now()
+	tick <- time.Now()
+	close(done)
+	<-finished
+
+	if got := p.callCount(); got < 2 {
+		t.Errorf("ping calls = %d, want >= 2", got)
+	}
+}
+
+// TestStartKeepAliveStopIsIdempotent verifies the stop function can be called
+// repeatedly (Close may run after the loop already exited) without panicking.
+func TestStartKeepAliveStopIsIdempotent(t *testing.T) {
+	stop := startKeepAlive(&fakePinger{}, time.Hour, nil)
+	stop()
+	stop()
+}

--- a/ssh.go
+++ b/ssh.go
@@ -21,16 +21,16 @@ import (
 )
 
 type sshHost struct {
-	name              string
-	env               map[string]string
-	client            *ssh.Client
-	sftpClient        *sftp.Client
-	fsys              fs.FS
-	vars              map[string]any
-	forwardAgent      bool
-	agentConn         net.Conn  // non-nil when agent forwarding is active; closed by Close
-	stopKeepAlive     func()    // non-nil when keepalives are running; stops them on Close
-	agentDeniedLogged sync.Once // logs an agent-forwarding denial at most once per host
+	name          string
+	env           map[string]string
+	client        *ssh.Client
+	sftpClient    *sftp.Client
+	fsys          fs.FS
+	vars          map[string]any
+	forwardAgent  bool
+	agentConn     net.Conn  // non-nil when agent forwarding is active; closed by Close
+	stopKeepAlive func()    // non-nil when keepalives are running; stops them on Close
+	agentFwdOnce  sync.Once // sends auth-agent-req on the first session only (see requestAgentForwarding)
 }
 
 // DialSSH connects to a remote host using ssh.
@@ -578,22 +578,30 @@ func (h *sshHost) NewCommand() (CmdRunner, error) {
 	}, nil
 }
 
-// requestAgentForwarding asks the server to forward the local SSH agent to the
-// session when this host was dialed with agent forwarding enabled. A denial is
-// non-fatal (matching OpenSSH's -A behavior) and continues without forwarding.
-// Because iago requests forwarding on every session but a server may honor it
-// only for some, the denial is logged at most once per host so a long run does
-// not spam the log with one line per session; a session that genuinely needs
-// the forwarded agent surfaces its own failure downstream.
+// requestAgentForwarding asks the server to forward the local SSH agent when
+// this host was dialed with agent forwarding enabled. The request is sent on
+// the first session only: OpenSSH's sshd honors auth-agent-req at most once
+// per connection and the grant is connection-wide — the agent socket persists
+// until the connection closes and is injected as SSH_AUTH_SOCK into every
+// later session. Requesting on every session therefore yields a spurious
+// "forwarding request denied" on each session after the first, so later
+// sessions skip the request and ride on the connection-wide grant. A denial
+// of the one real request is non-fatal (matching OpenSSH's -A behavior) and
+// is logged; a session that genuinely needs the forwarded agent surfaces its
+// own failure downstream.
+//
+// Note: this relies on OpenSSH's connection-wide forwarding model; a server
+// that scopes forwarding strictly per session would forward only to the first
+// session. OpenSSH is the deployment target.
 func (h *sshHost) requestAgentForwarding(session *ssh.Session) {
 	if !h.forwardAgent {
 		return
 	}
-	if err := agent.RequestAgentForwarding(session); err != nil {
-		h.agentDeniedLogged.Do(func() {
-			log.Printf("iago: agent forwarding denied for %s: %v (further denials on this host suppressed)", h.name, err)
-		})
-	}
+	h.agentFwdOnce.Do(func() {
+		if err := agent.RequestAgentForwarding(session); err != nil {
+			log.Printf("iago: agent forwarding denied for %s: %v", h.name, err)
+		}
+	})
 }
 
 // Close closes the connection to the host.

--- a/ssh.go
+++ b/ssh.go
@@ -6,6 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
+	"net"
+	"os"
 	"strings"
 	"sync"
 
@@ -13,15 +16,18 @@ import (
 	"github.com/relab/iago/sftpfs"
 	fs "github.com/relab/wrfs"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
 )
 
 type sshHost struct {
-	name       string
-	env        map[string]string
-	client     *ssh.Client
-	sftpClient *sftp.Client
-	fsys       fs.FS
-	vars       map[string]any
+	name         string
+	env          map[string]string
+	client       *ssh.Client
+	sftpClient   *sftp.Client
+	fsys         fs.FS
+	vars         map[string]any
+	forwardAgent bool
+	agentConn    net.Conn // non-nil when agent forwarding is active; closed by Close
 }
 
 // DialSSH connects to a remote host using ssh.
@@ -30,14 +36,14 @@ func DialSSH(name, addr string, cfg *ssh.ClientConfig) (Host, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newHostFromClient(name, client)
+	return newHostFromClient(name, client, false)
 }
 
 // dialViaProxy connects to a remote host by tunnelling through an already-established
 // SSH connection to a jump host. The jump client is not owned by the returned Host;
 // its lifetime is managed by the caller (typically [NewSSHGroup], which shares one
 // jump client across all targets that route through the same ProxyJump spec).
-func dialViaProxy(name, addr string, cfg *ssh.ClientConfig, jump *ssh.Client) (Host, error) {
+func dialViaProxy(name, addr string, cfg *ssh.ClientConfig, jump *ssh.Client, forwardAgent bool) (Host, error) {
 	ctx := context.Background()
 	if cfg.Timeout > 0 {
 		var cancel context.CancelFunc
@@ -52,27 +58,53 @@ func dialViaProxy(name, addr string, cfg *ssh.ClientConfig, jump *ssh.Client) (H
 	if err != nil {
 		return nil, err
 	}
-	return newHostFromClient(name, ssh.NewClient(ncc, chans, reqs))
+	return newHostFromClient(name, ssh.NewClient(ncc, chans, reqs), forwardAgent)
 }
 
 // newHostFromClient wraps an established *ssh.Client as a Host, creating the SFTP
-// sub-client and fetching the remote environment.
-func newHostFromClient(name string, client *ssh.Client) (Host, error) {
+// sub-client and fetching the remote environment. When forwardAgent is true the
+// local SSH agent is connected and registered with the client so that sessions
+// opened via [sshHost.NewCommand] and [sshHost.Execute] can request forwarding.
+func newHostFromClient(name string, client *ssh.Client, forwardAgent bool) (Host, error) {
+	var agentConn net.Conn
+	if forwardAgent {
+		sock := os.Getenv("SSH_AUTH_SOCK")
+		if sock == "" {
+			return nil, fmt.Errorf("iago: ForwardAgent requested for %s but SSH_AUTH_SOCK is not set", name)
+		}
+		var err error
+		agentConn, err = net.Dial("unix", sock)
+		if err != nil {
+			return nil, fmt.Errorf("iago: ForwardAgent requested for %s but could not connect to SSH agent: %w", name, err)
+		}
+		if err := agent.ForwardToAgent(client, agent.NewClient(agentConn)); err != nil {
+			_ = agentConn.Close()
+			return nil, fmt.Errorf("iago: failed to set up agent forwarding for %s: %w", name, err)
+		}
+	}
 	sftpClient, err := sftp.NewClient(client)
 	if err != nil {
+		if agentConn != nil {
+			_ = agentConn.Close()
+		}
 		return nil, err
 	}
 	env, err := fetchEnv(client)
 	if err != nil {
+		if agentConn != nil {
+			_ = agentConn.Close()
+		}
 		return nil, err
 	}
 	return &sshHost{
-		name:       name,
-		env:        env,
-		client:     client,
-		sftpClient: sftpClient,
-		fsys:       sftpfs.New(sftpClient, "/"),
-		vars:       make(map[string]any),
+		name:         name,
+		env:          env,
+		client:       client,
+		sftpClient:   sftpClient,
+		fsys:         sftpfs.New(sftpClient, "/"),
+		vars:         make(map[string]any),
+		forwardAgent: forwardAgent,
+		agentConn:    agentConn,
 	}, nil
 }
 
@@ -115,7 +147,7 @@ func NewSSHGroup(hostAliases []string, sshConfigFile string, opts ...GroupOption
 		return group, err
 	}
 
-	dialer := newGroupDialer(config, hostAliases)
+	dialer := newGroupDialer(config, hostAliases, cfg)
 	defer dialer.closeOnError(&err)
 
 	if err = dialer.prepareJumps(cfg); err != nil {
@@ -144,16 +176,18 @@ func NewSSHGroup(hostAliases []string, sshConfigFile string, opts ...GroupOption
 type groupDialer struct {
 	config      *sshConfig
 	aliases     []string
+	cfg         groupConfig
 	jumpClients map[string]*ssh.Client // proxy spec -> shared jump connection
 	jumpErrs    map[string]error       // proxy spec -> error establishing it
 	hosts       []Host                 // successfully dialed targets
 	dialErrs    map[string]error       // alias -> dial error; nil until first failure
 }
 
-func newGroupDialer(config *sshConfig, aliases []string) *groupDialer {
+func newGroupDialer(config *sshConfig, aliases []string, cfg groupConfig) *groupDialer {
 	return &groupDialer{
 		config:      config,
 		aliases:     aliases,
+		cfg:         cfg,
 		jumpClients: make(map[string]*ssh.Client),
 		jumpErrs:    make(map[string]error),
 	}
@@ -270,7 +304,7 @@ func (d *groupDialer) dialOne(alias string) sshDialResult {
 	if err != nil {
 		return sshDialResult{err: err}
 	}
-	host, err := dialTarget(alias, d.config, jump)
+	host, err := dialTarget(alias, d.config, jump, d.cfg.forwardAgent)
 	return sshDialResult{host: host, err: err}
 }
 
@@ -373,16 +407,27 @@ func dialJump(proxySpec string, config *sshConfig) (*ssh.Client, error) {
 // dialTarget dials a single target alias. When jump is non-nil the connection is
 // tunnelled through that shared jump client; otherwise it is dialed directly. The
 // jump client's lifetime is managed by the caller, not by the returned Host.
-func dialTarget(alias string, config *sshConfig, jump *ssh.Client) (Host, error) {
+// forceForwardAgent forces agent forwarding regardless of the SSH config value;
+// it is set when [ForwardAgent] was passed as a [GroupOption] to [NewSSHGroup].
+func dialTarget(alias string, config *sshConfig, jump *ssh.Client, forceForwardAgent bool) (Host, error) {
 	clientCfg, err := config.ClientConfig(alias)
 	if err != nil {
 		return nil, err
 	}
+	configForwardAgent, err := config.forwardAgent(alias)
+	if err != nil {
+		return nil, err
+	}
+	forwardAgent := forceForwardAgent || configForwardAgent
 	addr := config.ConnectAddr(alias)
 	if jump == nil {
-		return DialSSH(alias, addr, clientCfg)
+		client, err := ssh.Dial("tcp", addr, clientCfg)
+		if err != nil {
+			return nil, err
+		}
+		return newHostFromClient(alias, client, forwardAgent)
 	}
-	return dialViaProxy(alias, addr, clientCfg, jump)
+	return dialViaProxy(alias, addr, clientCfg, jump, forwardAgent)
 }
 
 // fetchEnv returns a map containing the environment variables of the ssh server.
@@ -437,6 +482,14 @@ func (h *sshHost) Execute(ctx context.Context, cmd string) (output string, err e
 		return "", err
 	}
 
+	if h.forwardAgent {
+		if err := agent.RequestAgentForwarding(session); err != nil {
+			// The server denied agent forwarding; log and continue without it.
+			// This matches OpenSSH's -A behaviour: a denial is a warning, not fatal.
+			log.Printf("iago: agent forwarding denied for %s: %v", h.name, err)
+		}
+	}
+
 	childCtx, cancel := context.WithCancel(ctx)
 	// create a channel to wait for helper goroutine
 	c := make(chan struct{})
@@ -463,6 +516,13 @@ func (h *sshHost) NewCommand() (CmdRunner, error) {
 	if err != nil {
 		return nil, err
 	}
+	if h.forwardAgent {
+		if err := agent.RequestAgentForwarding(session); err != nil {
+			// The server denied agent forwarding; log and continue without it.
+			// This matches OpenSSH's -A behaviour: a denial is a warning, not fatal.
+			log.Printf("iago: agent forwarding denied for %s: %v", h.name, err)
+		}
+	}
 	return sshCmd{
 		session: session,
 	}, nil
@@ -474,7 +534,11 @@ func (h *sshHost) NewCommand() (CmdRunner, error) {
 // jump connection is shared with other hosts and not closed here; it is closed
 // by [Group.Close].
 func (h *sshHost) Close() error {
-	return errors.Join(h.sftpClient.Close(), h.client.Close())
+	var agentErr error
+	if h.agentConn != nil {
+		agentErr = h.agentConn.Close()
+	}
+	return errors.Join(h.sftpClient.Close(), h.client.Close(), agentErr)
 }
 
 func (h *sshHost) SetVar(key string, val any) {

--- a/ssh.go
+++ b/ssh.go
@@ -560,11 +560,8 @@ func (h *sshHost) Execute(ctx context.Context, cmd string) (output string, err e
 	}()
 
 	session.Stdout = &buf
-	if err := session.Run(cmd); err != nil {
-		return "", nil
-	}
-
-	return buf.String(), nil
+	err = session.Run(cmd)
+	return buf.String(), err
 }
 
 func (h *sshHost) NewCommand() (CmdRunner, error) {

--- a/ssh.go
+++ b/ssh.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/pkg/sftp"
 	"github.com/relab/iago/sftpfs"
@@ -20,14 +21,15 @@ import (
 )
 
 type sshHost struct {
-	name         string
-	env          map[string]string
-	client       *ssh.Client
-	sftpClient   *sftp.Client
-	fsys         fs.FS
-	vars         map[string]any
-	forwardAgent bool
-	agentConn    net.Conn // non-nil when agent forwarding is active; closed by Close
+	name          string
+	env           map[string]string
+	client        *ssh.Client
+	sftpClient    *sftp.Client
+	fsys          fs.FS
+	vars          map[string]any
+	forwardAgent  bool
+	agentConn     net.Conn // non-nil when agent forwarding is active; closed by Close
+	stopKeepAlive func()   // non-nil when keepalives are running; stops them on Close
 }
 
 // DialSSH connects to a remote host using ssh.
@@ -36,14 +38,14 @@ func DialSSH(name, addr string, cfg *ssh.ClientConfig) (Host, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newHostFromClient(name, client, false)
+	return newHostFromClient(name, client, false, 0)
 }
 
 // dialViaProxy connects to a remote host by tunnelling through an already-established
 // SSH connection to a jump host. The jump client is not owned by the returned Host;
 // its lifetime is managed by the caller (typically [NewSSHGroup], which shares one
 // jump client across all targets that route through the same ProxyJump spec).
-func dialViaProxy(name, addr string, cfg *ssh.ClientConfig, jump *ssh.Client, forwardAgent bool) (Host, error) {
+func dialViaProxy(name, addr string, cfg *ssh.ClientConfig, jump *ssh.Client, forwardAgent bool, keepAlive time.Duration) (Host, error) {
 	ctx := context.Background()
 	if cfg.Timeout > 0 {
 		var cancel context.CancelFunc
@@ -58,14 +60,16 @@ func dialViaProxy(name, addr string, cfg *ssh.ClientConfig, jump *ssh.Client, fo
 	if err != nil {
 		return nil, err
 	}
-	return newHostFromClient(name, ssh.NewClient(ncc, chans, reqs), forwardAgent)
+	return newHostFromClient(name, ssh.NewClient(ncc, chans, reqs), forwardAgent, keepAlive)
 }
 
 // newHostFromClient wraps an established *ssh.Client as a Host, creating the SFTP
 // sub-client and fetching the remote environment. When forwardAgent is true the
 // local SSH agent is connected and registered with the client so that sessions
 // opened via [sshHost.NewCommand] and [sshHost.Execute] can request forwarding.
-func newHostFromClient(name string, client *ssh.Client, forwardAgent bool) (Host, error) {
+// When keepAlive is positive, a background goroutine sends periodic SSH
+// keepalives on the connection; it is stopped by [sshHost.Close].
+func newHostFromClient(name string, client *ssh.Client, forwardAgent bool, keepAlive time.Duration) (Host, error) {
 	var agentConn net.Conn
 	if forwardAgent {
 		sock := os.Getenv("SSH_AUTH_SOCK")
@@ -96,7 +100,7 @@ func newHostFromClient(name string, client *ssh.Client, forwardAgent bool) (Host
 		}
 		return nil, err
 	}
-	return &sshHost{
+	host := &sshHost{
 		name:         name,
 		env:          env,
 		client:       client,
@@ -105,7 +109,60 @@ func newHostFromClient(name string, client *ssh.Client, forwardAgent bool) (Host
 		vars:         make(map[string]any),
 		forwardAgent: forwardAgent,
 		agentConn:    agentConn,
-	}, nil
+	}
+	if keepAlive > 0 {
+		// On a dead connection the keepalive fails; close the client so any
+		// session blocked on a read returns instead of hanging indefinitely.
+		host.stopKeepAlive = startKeepAlive(client, keepAlive, func() { _ = client.Close() })
+	}
+	return host, nil
+}
+
+// keepAliveRequest is the OpenSSH-compatible global request name used to probe a
+// connection's liveness; the server replies but takes no other action.
+const keepAliveRequest = "keepalive@openssh.com"
+
+// keepAlivePinger is the subset of [ssh.Client] the keepalive loop needs, so the
+// loop can be exercised in tests without a live connection.
+type keepAlivePinger interface {
+	SendRequest(name string, wantReply bool, payload []byte) (bool, []byte, error)
+}
+
+// startKeepAlive launches a goroutine that pings client every interval and
+// returns a function that stops it. When a ping fails, onDead is invoked once
+// (typically to close the connection so blocked sessions return) and the loop
+// exits. The returned stop function is idempotent and safe to call from Close.
+func startKeepAlive(client keepAlivePinger, interval time.Duration, onDead func()) func() {
+	done := make(chan struct{})
+	ticker := time.NewTicker(interval)
+	go keepAliveLoop(client, ticker.C, onDead, done)
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			close(done)
+			ticker.Stop()
+		})
+	}
+}
+
+// keepAliveLoop pings client on every tick until either a ping fails (then it
+// calls onDead, if set, and returns) or done is closed (then it returns
+// silently). It is split from [startKeepAlive] so tests can drive the tick
+// channel deterministically.
+func keepAliveLoop(client keepAlivePinger, tick <-chan time.Time, onDead func(), done <-chan struct{}) {
+	for {
+		select {
+		case <-done:
+			return
+		case <-tick:
+			if _, _, err := client.SendRequest(keepAliveRequest, true, nil); err != nil {
+				if onDead != nil {
+					onDead()
+				}
+				return
+			}
+		}
+	}
 }
 
 // NewSSHGroup returns a new ssh group from the given host aliases. The sshConfigFile
@@ -304,7 +361,7 @@ func (d *groupDialer) dialOne(alias string) sshDialResult {
 	if err != nil {
 		return sshDialResult{err: err}
 	}
-	host, err := dialTarget(alias, d.config, jump, d.cfg.forwardAgent)
+	host, err := dialTarget(alias, d.config, jump, d.cfg.forwardAgent, d.cfg.keepAliveInterval)
 	return sshDialResult{host: host, err: err}
 }
 
@@ -409,7 +466,8 @@ func dialJump(proxySpec string, config *sshConfig) (*ssh.Client, error) {
 // jump client's lifetime is managed by the caller, not by the returned Host.
 // forceForwardAgent forces agent forwarding regardless of the SSH config value;
 // it is set when [ForwardAgent] was passed as a [GroupOption] to [NewSSHGroup].
-func dialTarget(alias string, config *sshConfig, jump *ssh.Client, forceForwardAgent bool) (Host, error) {
+// keepAlive, when positive, starts periodic SSH keepalives on the connection.
+func dialTarget(alias string, config *sshConfig, jump *ssh.Client, forceForwardAgent bool, keepAlive time.Duration) (Host, error) {
 	clientCfg, err := config.ClientConfig(alias)
 	if err != nil {
 		return nil, err
@@ -425,9 +483,9 @@ func dialTarget(alias string, config *sshConfig, jump *ssh.Client, forceForwardA
 		if err != nil {
 			return nil, err
 		}
-		return newHostFromClient(alias, client, forwardAgent)
+		return newHostFromClient(alias, client, forwardAgent, keepAlive)
 	}
-	return dialViaProxy(alias, addr, clientCfg, jump, forwardAgent)
+	return dialViaProxy(alias, addr, clientCfg, jump, forwardAgent, keepAlive)
 }
 
 // fetchEnv returns a map containing the environment variables of the ssh server.
@@ -485,7 +543,7 @@ func (h *sshHost) Execute(ctx context.Context, cmd string) (output string, err e
 	if h.forwardAgent {
 		if err := agent.RequestAgentForwarding(session); err != nil {
 			// The server denied agent forwarding; log and continue without it.
-			// This matches OpenSSH's -A behaviour: a denial is a warning, not fatal.
+			// This matches OpenSSH's -A behavior: a denial is a warning, not fatal.
 			log.Printf("iago: agent forwarding denied for %s: %v", h.name, err)
 		}
 	}
@@ -519,7 +577,7 @@ func (h *sshHost) NewCommand() (CmdRunner, error) {
 	if h.forwardAgent {
 		if err := agent.RequestAgentForwarding(session); err != nil {
 			// The server denied agent forwarding; log and continue without it.
-			// This matches OpenSSH's -A behaviour: a denial is a warning, not fatal.
+			// This matches OpenSSH's -A behavior: a denial is a warning, not fatal.
 			log.Printf("iago: agent forwarding denied for %s: %v", h.name, err)
 		}
 	}
@@ -534,6 +592,9 @@ func (h *sshHost) NewCommand() (CmdRunner, error) {
 // jump connection is shared with other hosts and not closed here; it is closed
 // by [Group.Close].
 func (h *sshHost) Close() error {
+	if h.stopKeepAlive != nil {
+		h.stopKeepAlive()
+	}
 	var agentErr error
 	if h.agentConn != nil {
 		agentErr = h.agentConn.Close()

--- a/ssh.go
+++ b/ssh.go
@@ -86,7 +86,10 @@ func newHostFromClient(name string, client *ssh.Client, forwardAgent bool, keepA
 			return nil, fmt.Errorf("iago: failed to set up agent forwarding for %s: %w", name, err)
 		}
 	}
-	sftpClient, err := sftp.NewClient(client)
+	sftpClient, err := sftp.NewClient(client,
+		sftp.UseConcurrentWrites(true),
+		sftp.UseConcurrentReads(true),
+	)
 	if err != nil {
 		if agentConn != nil {
 			_ = agentConn.Close()

--- a/ssh.go
+++ b/ssh.go
@@ -21,15 +21,16 @@ import (
 )
 
 type sshHost struct {
-	name          string
-	env           map[string]string
-	client        *ssh.Client
-	sftpClient    *sftp.Client
-	fsys          fs.FS
-	vars          map[string]any
-	forwardAgent  bool
-	agentConn     net.Conn // non-nil when agent forwarding is active; closed by Close
-	stopKeepAlive func()   // non-nil when keepalives are running; stops them on Close
+	name              string
+	env               map[string]string
+	client            *ssh.Client
+	sftpClient        *sftp.Client
+	fsys              fs.FS
+	vars              map[string]any
+	forwardAgent      bool
+	agentConn         net.Conn  // non-nil when agent forwarding is active; closed by Close
+	stopKeepAlive     func()    // non-nil when keepalives are running; stops them on Close
+	agentDeniedLogged sync.Once // logs an agent-forwarding denial at most once per host
 }
 
 // DialSSH connects to a remote host using ssh.
@@ -543,13 +544,7 @@ func (h *sshHost) Execute(ctx context.Context, cmd string) (output string, err e
 		return "", err
 	}
 
-	if h.forwardAgent {
-		if err := agent.RequestAgentForwarding(session); err != nil {
-			// The server denied agent forwarding; log and continue without it.
-			// This matches OpenSSH's -A behavior: a denial is a warning, not fatal.
-			log.Printf("iago: agent forwarding denied for %s: %v", h.name, err)
-		}
-	}
+	h.requestAgentForwarding(session)
 
 	childCtx, cancel := context.WithCancel(ctx)
 	// create a channel to wait for helper goroutine
@@ -577,16 +572,28 @@ func (h *sshHost) NewCommand() (CmdRunner, error) {
 	if err != nil {
 		return nil, err
 	}
-	if h.forwardAgent {
-		if err := agent.RequestAgentForwarding(session); err != nil {
-			// The server denied agent forwarding; log and continue without it.
-			// This matches OpenSSH's -A behavior: a denial is a warning, not fatal.
-			log.Printf("iago: agent forwarding denied for %s: %v", h.name, err)
-		}
-	}
+	h.requestAgentForwarding(session)
 	return sshCmd{
 		session: session,
 	}, nil
+}
+
+// requestAgentForwarding asks the server to forward the local SSH agent to the
+// session when this host was dialed with agent forwarding enabled. A denial is
+// non-fatal (matching OpenSSH's -A behavior) and continues without forwarding.
+// Because iago requests forwarding on every session but a server may honor it
+// only for some, the denial is logged at most once per host so a long run does
+// not spam the log with one line per session; a session that genuinely needs
+// the forwarded agent surfaces its own failure downstream.
+func (h *sshHost) requestAgentForwarding(session *ssh.Session) {
+	if !h.forwardAgent {
+		return
+	}
+	if err := agent.RequestAgentForwarding(session); err != nil {
+		h.agentDeniedLogged.Do(func() {
+			log.Printf("iago: agent forwarding denied for %s: %v (further denials on this host suppressed)", h.name, err)
+		})
+	}
 }
 
 // Close closes the connection to the host.

--- a/ssh_config.go
+++ b/ssh_config.go
@@ -160,6 +160,16 @@ func (cw *sshConfig) connectTimeout(hostAlias string) (time.Duration, error) {
 	return time.Duration(seconds) * time.Second, nil
 }
 
+// forwardAgent reports whether the SSH agent should be forwarded for the given
+// host alias. It returns true only when ForwardAgent is explicitly set to "yes".
+func (cw *sshConfig) forwardAgent(hostAlias string) (bool, error) {
+	val, err := cw.get(hostAlias, "ForwardAgent")
+	if err != nil {
+		return false, err
+	}
+	return strings.EqualFold(strings.TrimSpace(val), "yes"), nil
+}
+
 // ConnectAddr returns the connection address for the given host alias.
 // If no hostname is specified in the SSH config, it defaults to the provide host alias.
 // An empty string is returned if there was an error retrieving the hostname or port

--- a/ssh_config_test.go
+++ b/ssh_config_test.go
@@ -352,3 +352,32 @@ func TestParseHostsGlob(t *testing.T) {
 		})
 	}
 }
+
+func TestForwardAgent(t *testing.T) {
+	config, err := ParseSSHConfig("testdata/config")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		hostAlias string
+		want      bool
+	}{
+		{"ForwardAgentYes", "proxy-target", true},
+		{"ForwardAgentNotSet", "localhost", false},
+		{"ForwardAgentNotSetWildcard", "asdf", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := config.forwardAgent(tt.hostAlias)
+			if err != nil {
+				t.Fatalf("forwardAgent(%s): unexpected error: %v", tt.hostAlias, err)
+			}
+			if got != tt.want {
+				t.Errorf("forwardAgent(%s) = %v, want %v", tt.hostAlias, got, tt.want)
+			}
+		})
+	}
+}

--- a/testdata/config
+++ b/testdata/config
@@ -13,6 +13,7 @@ Host proxy-target
     ConnectTimeout 25
     User proxyuser
     ProxyJump jumpbox
+    ForwardAgent yes
     StrictHostKeyChecking no
 
 Host jumpbox


### PR DESCRIPTION
Adds SSH agent forwarding support so a remote host can authenticate onward to other hosts using the caller's local agent. Forwarding can be enabled per host via `ForwardAgent yes` in the SSH config file, or forced for every host in a group with the new `iago.ForwardAgent()` group option — equivalent to `ssh -A`. Also included in this branch:

- `iago.KeepAlive(interval)` group option, sending periodic SSH keepalives so idle connections aren't dropped by NAT/firewall timeouts.
- Concurrent SFTP reads/writes for faster uploads and downloads.
- `DownloadDir` for downloading a directory tree with progress reporting.
- Concurrent host closing in `Group.Close`.
- A fix so agent forwarding is requested only once per connection, not once per session.

Closes #31.

## Changes

- `ssh_config.go`: read the `ForwardAgent` option from the SSH config file.
- `ssh.go`: connect to the local agent and call `agent.ForwardToAgent` / `agent.RequestAgentForwarding` when forwarding is enabled; add the `KeepAlive` machinery; concurrent SFTP client options; concurrent `Group.Close`.
- `iago.go`: new `ForwardAgent()` and `KeepAlive()` group options.
- `fs.go`: `DownloadDir` struct with `Apply`, `Size`, and `ProgressFunc`.
- `iagotest/agent_forward_test.go`, `keepalive_test.go`, `ssh_config_test.go`: tests for the new behavior.
- `README.md`: document `ForwardAgent` and `KeepAlive`.

