### PR TITLE
Add group-level convenience helpers for command output, error collection, and remote path checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,66 @@ process or a Unix-domain socket.
 The shared connection is owned by the `Group` and closed by `group.Close()`.
 Closing an individual `iago.Host` closes only that host's tunnel.
 
+## Collecting results and errors
+
+`Group.Run` runs a task on every host but discards each host's return value beyond
+passing it to `ErrorHandler`. `iago.Collect` is the value-returning counterpart: it
+runs a function that returns `(T, error)` on every host and returns a
+`map[string]T` keyed by host name, plus a joined error for any host that failed.
+
+```go
+versions, err := iago.Collect(g, "Get kernel version", func(ctx context.Context, host iago.Host) (string, error) {
+	return iago.Output(ctx, host, "uname -r")
+})
+```
+
+`iago.Output` is a convenience wrapper around `Shell` for the common case of
+wanting a command's captured stdout as a string rather than streaming it to a
+caller-provided writer.
+
+By default, a group's `ErrorHandler` panics on the first task error. Pass
+`iago.WithErrorHandler` to `NewSSHGroup` to collect errors instead, using the
+`iago.Errors` accumulator:
+
+```go
+var errs iago.Errors
+g, err := iago.NewSSHGroup(hosts, configPath, iago.WithErrorHandler(errs.Handle))
+// ...
+g.Run("task", task)
+return errs.Err()
+```
+
+`Collect` uses this pattern internally, so its returned error is already joined
+the same way.
+
+## Shell command helpers
+
+`iago.Quote` wraps a string in single quotes so it is safe to embed as one
+argument in a `Shell` command run on a POSIX shell.
+
+`iago.FileExists` and `iago.DirExists` check whether a path exists on a remote
+host, backed by `test -f` / `test -d`:
+
+```go
+ok, err := iago.FileExists(ctx, host, "/etc/os-release")
+```
+
+Both distinguish "the path fails the test" (returns `false, nil`) from a
+genuine failure such as a transport error (returns `false, err`), using the
+`iago.ExitStatus` interface to inspect a remote command's exit code without
+importing `golang.org/x/crypto/ssh` directly.
+
+## UploadFile
+
+`iago.UploadFile` is a convenience wrapper around `Upload` for a single file,
+handling the `Path` conversion for an already-absolute local path and an
+absolute remote path so callers do not repeat that boilerplate at every call
+site:
+
+```go
+err := iago.UploadFile(ctx, host, "/local/path/binary", "/remote/path/binary", iago.NewPerm(0o755))
+```
+
 ## Example
 
 The following example downloads a file from each remote host.

--- a/cmd.go
+++ b/cmd.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 )
 
 // CmdRunner defines an interface for running commands on remote hosts.
@@ -96,4 +97,12 @@ func Output(ctx context.Context, host Host, cmd string) (string, error) {
 	var buf bytes.Buffer
 	err := Shell{Command: cmd, Stdout: &buf}.Apply(ctx, host)
 	return buf.String(), err
+}
+
+// Quote wraps s in single quotes so it is safe to embed as one argument in a
+// [Shell] command run on a POSIX shell. An embedded single quote is escaped
+// using the '\” idiom: end the quoted string, emit an escaped quote, and
+// resume quoting.
+func Quote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/cmd.go
+++ b/cmd.go
@@ -1,6 +1,7 @@
 package iago
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -85,4 +86,14 @@ func (sa Shell) Apply(ctx context.Context, host Host) (err error) {
 func pipe(dst io.Writer, src io.Reader, errChan chan error) {
 	_, err := io.Copy(dst, src)
 	errChan <- err
+}
+
+// Output runs cmd on host as a shell command and returns its captured
+// standard output. It is a convenience wrapper around [Shell] for the common
+// case of wanting a command's output as a string rather than streaming it to
+// a caller-provided writer.
+func Output(ctx context.Context, host Host, cmd string) (string, error) {
+	var buf bytes.Buffer
+	err := Shell{Command: cmd, Stdout: &buf}.Apply(ctx, host)
+	return buf.String(), err
 }

--- a/cmd.go
+++ b/cmd.go
@@ -106,3 +106,41 @@ func Output(ctx context.Context, host Host, cmd string) (string, error) {
 func Quote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
+
+// ExitStatus is implemented by an error carrying a remote process's exit
+// status, such as the golang.org/x/crypto/ssh package's *ssh.ExitError
+// returned by [Shell.Apply] when the remote command runs to completion but
+// exits non-zero. errors.AsType[iago.ExitStatus](err) extracts it from a
+// wrapped error (for example a [TaskError] from [Group.Run]) without the
+// caller importing golang.org/x/crypto/ssh, and distinguishes "the command
+// ran and exited non-zero" from "the command never completed" (a dial
+// failure, a dropped connection, and the like, none of which implement it).
+type ExitStatus interface {
+	error
+	ExitStatus() int
+}
+
+// FileExists reports whether path exists on host and is not a directory,
+// checked with a POSIX `test -f`. It returns false, nil when the remote
+// command determines the path fails the test (exit status 1); any other
+// failure (a transport error, a missing shell) is returned as an error.
+func FileExists(ctx context.Context, host Host, path string) (bool, error) {
+	return pathTest(ctx, host, "-f", path)
+}
+
+// DirExists reports whether path is a directory on host, checked with a
+// POSIX `test -d`. See [FileExists] for the exit-status contract.
+func DirExists(ctx context.Context, host Host, path string) (bool, error) {
+	return pathTest(ctx, host, "-d", path)
+}
+
+func pathTest(ctx context.Context, host Host, flag, path string) (bool, error) {
+	err := Shell{Command: "test " + flag + " " + Quote(path)}.Apply(ctx, host)
+	if err == nil {
+		return true, nil
+	}
+	if exitErr, ok := errors.AsType[ExitStatus](err); ok && exitErr.ExitStatus() == 1 {
+		return false, nil
+	}
+	return false, err
+}

--- a/cmd.go
+++ b/cmd.go
@@ -101,7 +101,7 @@ func Output(ctx context.Context, host Host, cmd string) (string, error) {
 
 // Quote wraps s in single quotes so it is safe to embed as one argument in a
 // [Shell] command run on a POSIX shell. An embedded single quote is escaped
-// using the '\” idiom: end the quoted string, emit an escaped quote, and
+// using the `'\''` idiom: end the quoted string, emit an escaped quote, and
 // resume quoting.
 func Quote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -1,0 +1,50 @@
+package iago
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// fakeCmdRunner is a minimal CmdRunner backing fakeHost.NewCommand in tests
+// that exercise Shell/Output without a real SSH connection. StdoutPipe
+// returns output in full immediately, so it is unsuitable for testing
+// streaming behavior, only the captured-result path Output relies on.
+type fakeCmdRunner struct {
+	output string
+	err    error
+}
+
+func (r *fakeCmdRunner) Run(string) error                         { return r.err }
+func (r *fakeCmdRunner) RunContext(context.Context, string) error { return r.err }
+func (r *fakeCmdRunner) Start(string) error                       { return r.err }
+func (r *fakeCmdRunner) Wait() error                              { return r.err }
+func (r *fakeCmdRunner) StdinPipe() (io.WriteCloser, error)       { return nil, errors.New("not supported") }
+func (r *fakeCmdRunner) StdoutPipe() (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader(r.output)), nil
+}
+func (r *fakeCmdRunner) StderrPipe() (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader("")), nil
+}
+
+func TestOutputCapturesStdout(t *testing.T) {
+	host := fakeHost{name: "h", cmd: &fakeCmdRunner{output: "hello\n"}}
+	out, err := Output(context.Background(), host, "echo hello")
+	if err != nil {
+		t.Fatalf("Output: %v", err)
+	}
+	if out != "hello\n" {
+		t.Fatalf("Output = %q, want %q", out, "hello\n")
+	}
+}
+
+func TestOutputPropagatesError(t *testing.T) {
+	wantErr := errors.New("boom")
+	host := fakeHost{name: "h", cmd: &fakeCmdRunner{err: wantErr}}
+	_, err := Output(context.Background(), host, "false")
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Output error = %v, want %v", err, wantErr)
+	}
+}

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -48,3 +48,23 @@ func TestOutputPropagatesError(t *testing.T) {
 		t.Fatalf("Output error = %v, want %v", err, wantErr)
 	}
 }
+
+func TestQuote(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "plain", in: "hello", want: "'hello'"},
+		{name: "spaces", in: "hello world", want: "'hello world'"},
+		{name: "single quote", in: "it's", want: `'it'\''s'`},
+		{name: "empty", in: "", want: "''"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Quote(tt.in); got != tt.want {
+				t.Errorf("Quote(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -66,5 +67,49 @@ func TestQuote(t *testing.T) {
 				t.Errorf("Quote(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
+	}
+}
+
+// fakeExitError is a minimal error implementing ExitStatus, standing in for
+// golang.org/x/crypto/ssh's *ssh.ExitError in tests.
+type fakeExitError struct{ status int }
+
+func (e fakeExitError) Error() string   { return "exit status " + strconv.Itoa(e.status) }
+func (e fakeExitError) ExitStatus() int { return e.status }
+
+func TestFileExists(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		want    bool
+		wantErr bool
+	}{
+		{name: "exists", err: nil, want: true},
+		{name: "does not exist", err: fakeExitError{status: 1}, want: false},
+		{name: "other exit status", err: fakeExitError{status: 2}, wantErr: true},
+		{name: "transport error", err: errors.New("connection reset"), wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host := fakeHost{name: "h", cmd: &fakeCmdRunner{err: tt.err}}
+			got, err := FileExists(context.Background(), host, "/some/path")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("FileExists error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Fatalf("FileExists = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDirExists(t *testing.T) {
+	host := fakeHost{name: "h", cmd: &fakeCmdRunner{err: fakeExitError{status: 1}}}
+	got, err := DirExists(context.Background(), host, "/some/dir")
+	if err != nil {
+		t.Fatalf("DirExists: %v", err)
+	}
+	if got {
+		t.Fatal("DirExists = true, want false")
 	}
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -83,3 +83,29 @@ func TestGroupRunCollectsErrors(t *testing.T) {
 		t.Fatalf("TaskError host = %q, want b", te.HostName)
 	}
 }
+
+func TestCollect(t *testing.T) {
+	g := NewGroup([]Host{fakeHost{name: "a"}, fakeHost{name: "b"}, fakeHost{name: "c"}})
+
+	results, err := Collect(g, "task", func(ctx context.Context, host Host) (int, error) {
+		if host.Name() == "b" {
+			return 0, errors.New("task failed")
+		}
+		return len(host.Name()), nil
+	})
+
+	if err == nil {
+		t.Fatal("expected an error from host b, got nil")
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %v, want exactly hosts a and c", results)
+	}
+	if _, ok := results["b"]; ok {
+		t.Fatal("host b returned an error but still has an entry")
+	}
+	for _, host := range []string{"a", "c"} {
+		if got, want := results[host], 1; got != want {
+			t.Fatalf("results[%q] = %d, want %d", host, got, want)
+		}
+	}
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -9,16 +9,18 @@ import (
 
 // fakeHost is a no-op Host for exercising Group.Run without a real
 // connection. Name is used to label task errors; cmd, if set, backs
-// NewCommand for tests that exercise Shell/Output.
+// NewCommand for tests that exercise Shell/Output; fsys, if set, backs GetFS
+// for tests that exercise Upload/UploadFile.
 type fakeHost struct {
 	name string
 	cmd  CmdRunner
+	fsys fs.FS
 }
 
 func (h fakeHost) Name() string                   { return h.name }
 func (h fakeHost) Address() string                { return h.name }
 func (h fakeHost) GetEnv(string) string           { return "" }
-func (h fakeHost) GetFS() fs.FS                   { return nil }
+func (h fakeHost) GetFS() fs.FS                   { return h.fsys }
 func (h fakeHost) NewCommand() (CmdRunner, error) { return h.cmd, nil }
 func (h fakeHost) Close() error                   { return nil }
 func (h fakeHost) SetVar(string, any)             {}

--- a/errors_test.go
+++ b/errors_test.go
@@ -7,15 +7,19 @@ import (
 	"testing"
 )
 
-// fakeHost is a no-op Host for exercising Group.Run without a real connection.
-// Only Name is meaningful; Group.Run uses it to label task errors.
-type fakeHost struct{ name string }
+// fakeHost is a no-op Host for exercising Group.Run without a real
+// connection. Name is used to label task errors; cmd, if set, backs
+// NewCommand for tests that exercise Shell/Output.
+type fakeHost struct {
+	name string
+	cmd  CmdRunner
+}
 
 func (h fakeHost) Name() string                   { return h.name }
 func (h fakeHost) Address() string                { return h.name }
 func (h fakeHost) GetEnv(string) string           { return "" }
 func (h fakeHost) GetFS() fs.FS                   { return nil }
-func (h fakeHost) NewCommand() (CmdRunner, error) { return nil, nil }
+func (h fakeHost) NewCommand() (CmdRunner, error) { return h.cmd, nil }
 func (h fakeHost) Close() error                   { return nil }
 func (h fakeHost) SetVar(string, any)             {}
 func (h fakeHost) GetVar(string) (any, bool)      { return nil, false }
@@ -51,7 +55,7 @@ func TestWithErrorHandlerOption(t *testing.T) {
 
 func TestGroupRunCollectsErrors(t *testing.T) {
 	var errs Errors
-	g := NewGroup([]Host{fakeHost{"a"}, fakeHost{"b"}, fakeHost{"c"}})
+	g := NewGroup([]Host{fakeHost{name: "a"}, fakeHost{name: "b"}, fakeHost{name: "c"}})
 	g.ErrorHandler = errs.Handle
 
 	g.Run("task", func(ctx context.Context, host Host) error {

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,81 @@
+package iago
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"testing"
+)
+
+// fakeHost is a no-op Host for exercising Group.Run without a real connection.
+// Only Name is meaningful; Group.Run uses it to label task errors.
+type fakeHost struct{ name string }
+
+func (h fakeHost) Name() string                   { return h.name }
+func (h fakeHost) Address() string                { return h.name }
+func (h fakeHost) GetEnv(string) string           { return "" }
+func (h fakeHost) GetFS() fs.FS                   { return nil }
+func (h fakeHost) NewCommand() (CmdRunner, error) { return nil, nil }
+func (h fakeHost) Close() error                   { return nil }
+func (h fakeHost) SetVar(string, any)             {}
+func (h fakeHost) GetVar(string) (any, bool)      { return nil, false }
+
+func TestErrorsCollector(t *testing.T) {
+	var errs Errors
+	if err := errs.Err(); err != nil {
+		t.Fatalf("empty collector: got %v, want nil", err)
+	}
+
+	e1 := errors.New("boom 1")
+	e2 := errors.New("boom 2")
+	errs.Handle(e1)
+	errs.Handle(e2)
+
+	got := errs.Err()
+	if !errors.Is(got, e1) || !errors.Is(got, e2) {
+		t.Fatalf("joined error %v does not wrap both %v and %v", got, e1, e2)
+	}
+}
+
+func TestWithErrorHandlerOption(t *testing.T) {
+	var errs Errors
+	cfg := applyGroupOptions(WithErrorHandler(errs.Handle))
+	if cfg.errorHandler == nil {
+		t.Fatal("WithErrorHandler did not set errorHandler")
+	}
+	cfg.errorHandler(errors.New("boom"))
+	if errs.Err() == nil {
+		t.Fatal("handler set by the option did not reach the collector")
+	}
+}
+
+func TestGroupRunCollectsErrors(t *testing.T) {
+	var errs Errors
+	g := NewGroup([]Host{fakeHost{"a"}, fakeHost{"b"}, fakeHost{"c"}})
+	g.ErrorHandler = errs.Handle
+
+	g.Run("task", func(ctx context.Context, host Host) error {
+		if host.Name() == "b" {
+			return errors.New("task failed")
+		}
+		return nil
+	})
+
+	err := errs.Err()
+	if err == nil {
+		t.Fatal("expected an error from host b, got nil")
+	}
+	// Only host b fails, so exactly one error should be collected.
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		if n := len(joined.Unwrap()); n != 1 {
+			t.Fatalf("collected %d errors, want 1", n)
+		}
+	}
+	var te TaskError
+	if !errors.As(err, &te) {
+		t.Fatalf("error %v is not a TaskError", err)
+	}
+	if te.HostName != "b" {
+		t.Fatalf("TaskError host = %q, want b", te.HostName)
+	}
+}

--- a/fs.go
+++ b/fs.go
@@ -122,6 +122,27 @@ func (u Upload) Apply(ctx context.Context, host Host) error {
 	return copyAction{src: u.Src, dest: u.Dest, perm: u.Perm, fetch: false}.Apply(ctx, host)
 }
 
+// UploadFile uploads the local file at localPath to remotePath on host with
+// the given permissions. It is a convenience wrapper around [Upload] for a
+// single file, handling the [Path] conversion of an already-absolute local
+// path and an absolute remote path so callers do not repeat that boilerplate
+// at every call site.
+func UploadFile(ctx context.Context, host Host, localPath, remotePath string, perm Perm) error {
+	absLocal, err := filepath.Abs(localPath)
+	if err != nil {
+		return err
+	}
+	src, err := NewPathFromAbs(absLocal)
+	if err != nil {
+		return err
+	}
+	dest, err := NewPath(filepath.Dir(remotePath), filepath.Base(remotePath))
+	if err != nil {
+		return err
+	}
+	return Upload{Src: src, Dest: dest, Perm: perm}.Apply(ctx, host)
+}
+
 // Download downloads a file or directory from a remote host.
 // For each host in a group, a subdirectory named after the host is created
 // under Dest so that results from multiple hosts do not collide.

--- a/fs_internal_test.go
+++ b/fs_internal_test.go
@@ -1,0 +1,33 @@
+package iago
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/relab/wrfs"
+)
+
+func TestUploadFile(t *testing.T) {
+	srcDir, dstDir := t.TempDir(), t.TempDir()
+
+	srcPath := filepath.Join(srcDir, "payload.bin")
+	want := []byte("hello, host")
+	if err := os.WriteFile(srcPath, want, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	host := fakeHost{name: "h", fsys: wrfs.DirFS(dstDir)}
+	if err := UploadFile(context.Background(), host, srcPath, "/uploaded.bin", NewPerm(0o644)); err != nil {
+		t.Fatalf("UploadFile: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dstDir, "uploaded.bin"))
+	if err != nil {
+		t.Fatalf("reading uploaded file: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("uploaded content = %q, want %q", got, want)
+	}
+}

--- a/iago.go
+++ b/iago.go
@@ -201,6 +201,36 @@ func (g Group) Run(name string, f func(context.Context, Host) error) {
 	}
 }
 
+// Collect runs fn concurrently on every host in g and returns each host's
+// result keyed by host name, the value-returning counterpart to [Group.Run].
+// A host whose fn returns a non-nil error contributes no entry to the map;
+// that error is still delivered to g.ErrorHandler exactly as in Run, and the
+// joined result is returned as Collect's second value (nil when every host
+// succeeded). Writes into the returned map are synchronized, so callers need
+// no mutex of their own.
+//
+// A legitimate "nothing to report" for one host — an empty result, not a
+// failure — should be represented as a zero-value T with a nil error, so it
+// still gets an entry; reserve the error return for genuine command
+// failures and filter zero-value entries out afterward if desired.
+func Collect[T any](g Group, name string, fn func(context.Context, Host) (T, error)) (map[string]T, error) {
+	results := make(map[string]T, len(g.Hosts))
+	var mu sync.Mutex
+	var errs Errors
+	g.ErrorHandler = errs.Handle
+	g.Run(name, func(ctx context.Context, host Host) error {
+		v, err := fn(ctx, host)
+		if err != nil {
+			return err
+		}
+		mu.Lock()
+		results[host.Name()] = v
+		mu.Unlock()
+		return nil
+	})
+	return results, errs.Err()
+}
+
 // Close closes any connections to hosts and any group-owned shared resources
 // (such as ProxyJump connections shared across hosts in this group).
 // Hosts are closed concurrently; shared resources (e.g. ProxyJump clients)

--- a/iago.go
+++ b/iago.go
@@ -79,6 +79,7 @@ type groupConfig struct {
 	dialConcurrency   int
 	forwardAgent      bool
 	keepAliveInterval time.Duration
+	errorHandler      ErrorHandler
 }
 
 func applyGroupOptions(opts ...GroupOption) groupConfig {
@@ -135,6 +136,22 @@ func KeepAlive(interval time.Duration) GroupOption {
 func ForwardAgent() GroupOption {
 	return func(cfg *groupConfig) {
 		cfg.forwardAgent = true
+	}
+}
+
+// WithErrorHandler returns a [GroupOption] that sets the [ErrorHandler] of the
+// group returned by [NewSSHGroup]. Without it the group defaults to [Panic],
+// matching [NewGroup]. Pass a shared [Errors] collector's Handle method to
+// gather task errors instead of panicking:
+//
+//	var errs iago.Errors
+//	g, err := iago.NewSSHGroup(aliases, cfg, iago.WithErrorHandler(errs.Handle))
+//	// ...
+//	g.Run("task", task)
+//	return errs.Err()
+func WithErrorHandler(h ErrorHandler) GroupOption {
+	return func(cfg *groupConfig) {
+		cfg.errorHandler = h
 	}
 }
 
@@ -215,6 +232,40 @@ func Panic(e error) {
 // Ignore ignores errors.
 func Ignore(e error) {
 	log.Println(e, "(ignored)")
+}
+
+// Errors is an [ErrorHandler] that accumulates the errors passed to it for
+// later retrieval instead of panicking like [Panic]. It is the collecting
+// counterpart to [Panic] and [Ignore], for a caller that runs a task on every
+// host and then acts on the joined result:
+//
+//	var errs iago.Errors
+//	g.ErrorHandler = errs.Handle
+//	g.Run("task", task)
+//	return errs.Err()
+//
+// [Group.Run] invokes the handler sequentially, so within a single Run the
+// collector is uncontended; the mutex makes it safe to share one Errors across
+// concurrent Runs as well. The zero value is ready to use.
+type Errors struct {
+	mu   sync.Mutex
+	errs []error
+}
+
+// Handle records err. It satisfies the [ErrorHandler] signature, so it can be
+// assigned to [Group.ErrorHandler] or passed to [WithErrorHandler].
+func (e *Errors) Handle(err error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.errs = append(e.errs, err)
+}
+
+// Err returns the recorded errors joined with [errors.Join], or nil when none
+// were recorded.
+func (e *Errors) Err() error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return errors.Join(e.errs...)
 }
 
 func safeClose(closer io.Closer, errPtr *error, ignoredErrs ...error) {

--- a/iago.go
+++ b/iago.go
@@ -202,20 +202,15 @@ func (g Group) Run(name string, f func(context.Context, Host) error) {
 }
 
 // Collect runs fn concurrently on every host in g and returns each host's
-// result keyed by host name, the value-returning counterpart to [Group.Run].
-// A host whose fn returns a non-nil error contributes no entry to the map;
-// that error is still delivered to g.ErrorHandler exactly as in Run, and the
-// joined result is returned as Collect's second value (nil when every host
-// succeeded). Writes into the returned map are synchronized, so callers need
-// no mutex of their own.
-//
-// A legitimate "nothing to report" for one host — an empty result, not a
-// failure — should be represented as a zero-value T with a nil error, so it
-// still gets an entry; reserve the error return for genuine command
-// failures and filter zero-value entries out afterward if desired.
+// result keyed by host name. A host whose fn returns a non-nil error
+// contributes no entry to the map; those errors are joined and returned as
+// Collect's second value (nil when every host succeeded).
 func Collect[T any](g Group, name string, fn func(context.Context, Host) (T, error)) (map[string]T, error) {
 	results := make(map[string]T, len(g.Hosts))
 	var mu sync.Mutex
+	// Collect its own errors rather than g's original ErrorHandler, so
+	// they can be joined and returned instead of panicking or being
+	// silently handled elsewhere.
 	var errs Errors
 	g.ErrorHandler = errs.Handle
 	g.Run(name, func(ctx context.Context, host Host) error {

--- a/ssh.go
+++ b/ssh.go
@@ -418,6 +418,9 @@ func (d *groupDialer) allFailedError() error {
 func (d *groupDialer) group() Group {
 	group := NewGroup(d.hosts)
 	group.DialErrors = d.dialErrs
+	if d.cfg.errorHandler != nil {
+		group.ErrorHandler = d.cfg.errorHandler
+	}
 	for _, jc := range d.jumpClients {
 		group.sharedClosers = append(group.sharedClosers, jc)
 	}


### PR DESCRIPTION
Adds a small set of helpers on top of the existing `Group`/`Shell`/`Upload` primitives, removing boilerplate that's otherwise repeated at every call site in scripts using iago:

- `Errors` / `WithErrorHandler`: collect task errors instead of panicking, joined via `errors.Join`; `WithErrorHandler` wires a handler into `NewSSHGroup` and `ssh.go`'s `groupDialer.group()` now propagates it onto the constructed `Group`.
- `Output`: `Shell` wrapper that returns captured stdout as a string.
- `Collect`: value-returning counterpart to `Group.Run`, returning a `map[string]T` keyed by host name plus a joined error.
- `Quote`: single-quotes a string for safe embedding as a `Shell` argument on a POSIX shell.
- `ExitStatus`: interface for extracting a remote process's exit status from a (possibly wrapped) error, without importing `golang.org/x/crypto/ssh` directly.
- `FileExists` / `DirExists`: `test -f` / `test -d` on a remote host, using `ExitStatus` to distinguish "path fails the test" (`false, nil`) from a genuine failure (`false, err`).
- `UploadFile`: `Upload` wrapper for a single file, handling the `Path` conversion for already-absolute local/remote paths.

README updated with a usage example for each addition.

Closes #33.